### PR TITLE
Support for Elevator Call

### DIFF
--- a/core/fields.ts
+++ b/core/fields.ts
@@ -10,7 +10,7 @@ export enum Types {
     INFO = 5,
     HEALTHCARE = 6,
     SETTING = 7,
-    ELEVATOR_CELL = 8,
+    ELEVATOR_CALL = 8,
     ETCETERA = 9,
     APPLICATION_LOG = 100
     

--- a/core/utils.ts
+++ b/core/utils.ts
@@ -81,7 +81,7 @@ export class Utils {
                 return HealthcareSubTypes;
             case Types.SETTING:
                 return SettingSubTypes;
-            case Types.ELEVATOR_CELL:
+            case Types.ELEVATOR_CALL:
                 return ElevatorCallSubTypes;
             case Types.ETCETERA:
                 return EtceteraSubTypes;

--- a/homebridge/accessories/accessories.ts
+++ b/homebridge/accessories/accessories.ts
@@ -18,17 +18,11 @@ type ServiceType = WithUUID<typeof Service>;
 
 export class Accessories<T extends AccessoryInterface> {
 
-    protected readonly log: Logging;
-    protected readonly api: API;
-    protected readonly config?: DaelimConfig;
-
     protected client?: Client;
 
     protected readonly accessories: PlatformAccessory[] = [];
-    protected readonly serviceTypes: ServiceType[];
-    protected readonly accessoryTypes: string[];
 
-    private lastInitRequestTimestamp: number;
+    private lastInitRequestTimestamp: number = -1;
 
     /**
      * Accessories class
@@ -41,14 +35,12 @@ export class Accessories<T extends AccessoryInterface> {
      *                       TODO: This is anti-pattern. Must be changed in near future.
      * @param serviceTypes Array of service types that would be used for registering accessory to Homebridge
      */
-    constructor(log: Logging, api: API, config: DaelimConfig | undefined, accessoryTypes: string[], serviceTypes: ServiceType[]) {
-        this.log = log;
-        this.api = api;
-        this.config = config;
-        this.accessoryTypes = accessoryTypes;
-        this.serviceTypes = serviceTypes;
+    constructor(protected readonly log: Logging,
+                protected readonly api: API,
+                protected readonly config: DaelimConfig | undefined,
+                protected readonly accessoryTypes: string[],
+                protected readonly serviceTypes: ServiceType[]) {
         this.serviceTypes.push(api.hap.Service.AccessoryInformation);
-        this.lastInitRequestTimestamp = -1;
     }
 
     setClient(client: Client) {
@@ -164,6 +156,9 @@ export class Accessories<T extends AccessoryInterface> {
             }
         }
         throw `Invalid service type '${serviceType}' in services [${services.map((service) => service.displayName).join(", ")}]`
+    }
+
+    registerAccessories() {
     }
 
     registerListeners() {

--- a/homebridge/accessories/elevator.ts
+++ b/homebridge/accessories/elevator.ts
@@ -1,0 +1,113 @@
+import {Accessories, AccessoryInterface} from "./accessories";
+import {
+    API,
+    CharacteristicEventTypes,
+    CharacteristicGetCallback,
+    CharacteristicSetCallback,
+    CharacteristicValue,
+    Logging,
+    PlatformAccessory,
+    Service
+} from "homebridge";
+import {DaelimConfig} from "../../core/interfaces/daelim-config";
+import {ElevatorCallSubTypes, Types} from "../../core/fields";
+
+interface ElevatorAccessoryInterface extends AccessoryInterface {
+
+    timeoutId: number
+    called: boolean
+
+}
+
+const ELEVATOR_DEVICE_ID = "EV-000000";
+const ELEVATOR_DISPLAY_NAME = "엘레베이터";
+const ELEVATOR_TIMEOUT_DURATION = 30 * 1000; // 30 seconds
+
+export class ElevatorAccessories extends Accessories<ElevatorAccessoryInterface> {
+
+    constructor(log: Logging, api: API, config: DaelimConfig | undefined) {
+        super(log, api, config, ["elevator"], [api.hap.Service.Switch]);
+    }
+
+    async identify(accessory: PlatformAccessory): Promise<void> {
+        await super.identify(accessory);
+
+        this.log.warn("Elevator Calling accessory does not support identification due to it is public utility");
+    }
+
+    configureAccessory(accessory: PlatformAccessory, services: Service[]) {
+        super.configureAccessory(accessory, services);
+        const service = this.ensureServiceAvailability(this.api.hap.Service.Switch, services);
+        service.getCharacteristic(this.api.hap.Characteristic.On)
+            .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                if(accessory.context.called) {
+                    if(!value) {
+                        // If the elevator have called, but attempt to set not-called state
+                        const nextState = accessory.context.called;
+                        setTimeout(() => {
+                            service.setCharacteristic(this.api.hap.Characteristic.On, nextState);
+                        }, 0);
+                    }
+                    callback(undefined);
+                    return;
+                }
+                if(!!value) {
+                    const response = await this.client?.sendDeferredRequest(
+                        {},
+                        Types.ELEVATOR_CALL,
+                        ElevatorCallSubTypes.CALL_REQUEST,
+                        ElevatorCallSubTypes.CALL_RESPONSE,
+                        (_) => true
+                    ).catch(_ => {
+                        return undefined;
+                    });
+                    if(response === undefined) {
+                        callback(new Error('TIMED OUT'));
+                        return;
+                    }
+                    this.enqueueElevatorCallTimeout(accessory);
+                }
+                accessory.context.init = true;
+                accessory.context.called = value;
+                callback(undefined);
+            })
+            .on(CharacteristicEventTypes.GET, async (callback: CharacteristicGetCallback) => {
+                this.client?.checkKeepAlive();
+                callback(undefined, accessory.context.called);
+            });
+    }
+
+    enqueueElevatorCallTimeout(accessory: PlatformAccessory) {
+        if(accessory.context.timeoutId !== -1) {
+            clearTimeout(accessory.context.timeoutId);
+        }
+        accessory.context.timeoutId = setTimeout(() => {
+            this.invalidateElevatorContextState();
+        }, ELEVATOR_TIMEOUT_DURATION);
+    }
+
+    invalidateElevatorContextState() {
+        const accessory = this.findAccessoryWithDeviceID(ELEVATOR_DEVICE_ID);
+        if(accessory) {
+            if(accessory.context.timeoutId !== -1) {
+                clearTimeout(accessory.context.timeoutId);
+            }
+            accessory.context.timeoutId = -1;
+            accessory.context.called = false;
+            this.findService(accessory, this.api.hap.Service.Switch, (service) => {
+                service.setCharacteristic(this.api.hap.Characteristic.On, accessory.context.called);
+            });
+        }
+    }
+
+    registerAccessories() {
+        this.addAccessory({
+            deviceID: ELEVATOR_DEVICE_ID,
+            displayName: ELEVATOR_DISPLAY_NAME,
+            init: false, // Lazy-init when characteristic update
+            timeoutId: -1,
+            called: false // inactive as a default since this is on-only switch
+        });
+    }
+
+}

--- a/homebridge/daelim-smarthome-platform.ts
+++ b/homebridge/daelim-smarthome-platform.ts
@@ -1,6 +1,6 @@
 import {
     API,
-    APIEvent,
+    APIEvent, DynamicPlatformPlugin,
     Logging,
     PlatformAccessory,
     PlatformConfig,
@@ -13,12 +13,13 @@ import {Accessories, AccessoryInterface} from "./accessories/accessories";
 import {OutletAccessories} from "./accessories/outlet";
 import {HeaterAccessories} from "./accessories/heater";
 import {GasAccessories} from "./accessories/gas";
+import {ElevatorAccessories} from "./accessories/elevator";
 
 export = (api: API) => {
     api.registerPlatform(Utils.PLATFORM_NAME, DaelimSmartHomePlatform);
 }
 
-class DaelimSmartHomePlatform {
+class DaelimSmartHomePlatform implements DynamicPlatformPlugin {
 
     private readonly log: Logging;
     private readonly api: API;
@@ -37,6 +38,7 @@ class DaelimSmartHomePlatform {
         this.accessories.push(new OutletAccessories(this.log, this.api, this.config));
         this.accessories.push(new HeaterAccessories(this.log, this.api, this.config));
         this.accessories.push(new GasAccessories(this.log, this.api, this.config));
+        this.accessories.push(new ElevatorAccessories(this.log, this.api, this.config));
 
         log.info("Daelim-SmartHome finished initializing!");
 
@@ -61,7 +63,6 @@ class DaelimSmartHomePlatform {
         };
     }
 
-    /* override */
     configureAccessory(accessory: PlatformAccessory): void {
         for(const accessories of this.accessories) {
             if(!accessories.getAccessoryTypes().includes(accessory.context.accessoryType)) {
@@ -87,6 +88,7 @@ class DaelimSmartHomePlatform {
         this.accessories.forEach(accessories => {
             accessories.setClient(this.client!);
             accessories.registerListeners();
+            accessories.registerAccessories();
         });
 
         this.client.startService();


### PR DESCRIPTION
# Elevator Call

Related to #20 

The accessory service is `Switch`.
I couldn't find other better accessory service type.

## Changes
- Add Elevator Call Accessory
- Fix Typos

## How It Works

- The switch always keeps off-state. (One-way switch)
- Once the switch have turned on, the plugin requests the elevator to come up.
- The switch keeps on-state during 30 seconds timeout.
- Since there is no notification about arrival of the elevator, the switch would be always on-state for 30 seconds.
- If the switch have turned off within 30 seconds, it means the request have been failed.