### PR TITLE
Fix for lightbulbs with fewer brightness options

### DIFF
--- a/homebridge/accessories/accessories.ts
+++ b/homebridge/accessories/accessories.ts
@@ -125,6 +125,10 @@ export class Accessories<T extends AccessoryInterface> {
         return false;
     }
 
+    protected checkForciblyRefreshable(context: T, force: boolean) {
+        return !(force && context.init);
+    }
+
     private requestAccessoryInit() {
         const currentTime = Date.now();
         if(this.lastInitRequestTimestamp != -1 && currentTime - this.lastInitRequestTimestamp < 10 * 60) {

--- a/homebridge/accessories/gas.ts
+++ b/homebridge/accessories/gas.ts
@@ -131,11 +131,12 @@ export class GasAccessories extends Accessories<GasAccessoryInterface> {
     refreshGasValveState(items: any[], force: boolean = false) {
         for(let i = 0; i < items.length; i++) {
             const item = items[i];
-
             const deviceID = item['uid'];
-
             const accessory = this.findAccessoryWithDeviceID(deviceID);
             if(accessory) {
+                if(!this.checkForciblyRefreshable(accessory.context as GasAccessoryInterface, force)) {
+                    continue;
+                }
                 accessory.context.on = item['arg1'] === 'on';
                 accessory.context.init = true;
                 if(force) {

--- a/homebridge/accessories/heater.ts
+++ b/homebridge/accessories/heater.ts
@@ -159,10 +159,12 @@ export class HeaterAccessories extends Accessories<HeaterAccessoryInterface> {
     refreshHeaterState(items: any[], force: boolean = false) {
         for(let i = 0; i < items.length; i++) {
             const item = items[i];
-
             const deviceID = item['uid'];
             const accessory = this.findAccessoryWithDeviceID(deviceID);
             if(accessory) {
+                if(!this.checkForciblyRefreshable(accessory.context as HeaterAccessoryInterface, force)) {
+                    continue;
+                }
                 const active = item['arg1'] === 'on';
                 const desiredTemperature = parseInt(item['arg2']);
                 const currentTemperature = parseInt(item['arg3']);

--- a/homebridge/accessories/outlet.ts
+++ b/homebridge/accessories/outlet.ts
@@ -103,11 +103,12 @@ export class OutletAccessories extends Accessories<OutletAccessoryInterface> {
     refreshOutletState(items: any[], force: boolean = false) {
         for(let i = 0; i < items.length; i++) {
             const item = items[i];
-
             const deviceID = item['uid'];
-
             const accessory = this.findAccessoryWithDeviceID(deviceID);
             if(accessory) {
+                if(!this.checkForciblyRefreshable(accessory.context as OutletAccessoryInterface, force)) {
+                    continue;
+                }
                 accessory.context.on = item['arg1'] === 'on';
                 accessory.context.init = true;
                 if(force) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,20 @@
     "": {
       "name": "homebridge-daelim-smarthome",
       "version": "1.3.0",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/OrigamiDream"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/OrigamiDream"
+        },
+        {
+          "type": "toss",
+          "url": "https://toss.me/steinway"
+        }
+      ],
       "license": "GPL-3.0-only",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^0.0.19",


### PR DESCRIPTION
# Lightbulbs with Fewer Brightness Options

## Related
- #24

## Symptoms
- Lightbulbs with fewer brightness options are crashing with the current implementation

## Changes
- Add support for lightbulbs with fewer brightness options
- Improve performance by removing forcible characteristic refresh every accessory updates
- Update package-lock.json