### PR TITLE
Improve MMF server keep-alive algorithm

### DIFF
--- a/core/network.ts
+++ b/core/network.ts
@@ -128,7 +128,7 @@ export class NetworkHandler {
 
     disconnect() {
         if(this.socket) {
-            this.socket.end();
+            this.socket.destroy();
             this.socket = undefined;
         }
     }

--- a/homebridge/accessories/accessories.ts
+++ b/homebridge/accessories/accessories.ts
@@ -136,6 +136,11 @@ export class Accessories<T extends AccessoryInterface> {
     }
 
     addAccessory(context: T) {
+        if(this.client?.isNetworkRefreshing()) {
+            // This prevents changing the accessories to uninitialized state while refreshing the connection.
+            // Uninitialized state makes the accessories are no response in Home app.
+            return;
+        }
         // Verify cached accessory availability
         for(const fn of UUID_SEED_COMBINATIONS) {
             const uuid = this.api.hap.uuid.generate(fn(context));


### PR DESCRIPTION
Related:
- #43 

Add a new refreshing handler that destroys MMF server connection immediately and reconnect to the server.
Sending dummy packet has been removed.