### PR TITLE
PR v1.4.2-beta to main branch

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@ homebridge-ui/
 core/
 complexes/
 branding/
+!/dist/*
 
 # Ignore temporary volume
 .homebridge*

--- a/homebridge/accessories/accessories.ts
+++ b/homebridge/accessories/accessories.ts
@@ -242,7 +242,7 @@ export class Accessories<T extends AccessoryInterface> {
         const accessory = new this.api.platformAccessory(context.displayName, uuid);
 
         let services = this.serviceTypes.map((serviceType) => {
-            return accessory.getService(serviceType) || accessory.addService(serviceType, context.displayName);
+            return accessory.getService(serviceType) || accessory.addService(serviceType, context.displayName, serviceType.UUID);
         })
         accessory.context = context;
         accessory.context.version = Utils.currentSemanticVersion().toString();

--- a/homebridge/daelim-smarthome-platform.ts
+++ b/homebridge/daelim-smarthome-platform.ts
@@ -78,7 +78,7 @@ class DaelimSmartHomePlatform implements DynamicPlatformPlugin {
                 continue;
             }
             const services = accessories.getServiceTypes().map((serviceType) => {
-                return accessory.getService(serviceType) || accessory.addService(serviceType, accessory.displayName);
+                return accessory.getService(serviceType) || accessory.addService(serviceType, accessory.displayName, serviceType.UUID);
             });
             if(services.length > 0) {
                 accessories.configureAccessory(accessory, services);

--- a/logs/v1.4.2.md
+++ b/logs/v1.4.2.md
@@ -1,0 +1,10 @@
+v1.4.2 — Update for minor changes
+# CHANGELOGS
+
+- TypeScript 컴파일 중 문제점 개선
+- Node.js 의존성 보안 업데이트
+  - axios 0.22.0 → axios 1.6.0 [#93](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/93)
+  - protobufjs 6.11.3 → protobufjs 6.11.4 [#95](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/95)
+  - xml2js 0.4.23 → xml2js 0.5.0 [#96](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/96)
+  - homebridge 1.5.1 → homebridge 1.7.0 [#96](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/96)
+  - follow-redirects 1.15.3 → follow-redirects 1.15.4 [#97](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/97)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-daelim-smarthome",
-  "version": "1.4.1",
+  "version": "1.4.2-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daelim-smarthome",
-      "version": "1.4.1",
+      "version": "1.4.2-beta.0",
       "funding": [
         {
           "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge DL E&C Smart Home",
   "name": "homebridge-daelim-smarthome",
-  "version": "1.4.1",
+  "version": "1.4.2-beta.0",
   "description": "A third-party Homebridge platform plugin for DL E&C SmartHome",
   "main": "dist/homebridge/daelim-smarthome-platform.js",
   "keywords": [

--- a/scripts/deploy-docker.sh
+++ b/scripts/deploy-docker.sh
@@ -37,7 +37,7 @@ docker run \
   -p 8581:8581/tcp \
   -v $root_dir:/homebridge \
   -d \
-  oznu/homebridge:ubuntu
+  homebridge/homebridge:latest
 
 echo "Waiting for the Docker container up..."
 until [ "`docker inspect -f {{.State.Running}} homebridge`" == "true" ]; do


### PR DESCRIPTION
# DL E&C Homebridge v1.4.2

## Changes
- Fix TypeScript compilation problem
- Node.js deps security updates
  - axios 0.22.0 → axios 1.6.0 [#93](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/93)
  - protobufjs 6.11.3 → protobufjs 6.11.4 [#95](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/95)
  - xml2js 0.4.23 → xml2js 0.5.0 [#96](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/96)
  - homebridge 1.5.1 → homebridge 1.7.0 [#96](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/96)
  - follow-redirects 1.15.3 → follow-redirects 1.15.4 [#97](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/97)