### PR TITLE
Fix Smart eLife HVAC target temperature parsing

### DIFF
--- a/homebridge/accessories/smart-elife/air-conditioner.ts
+++ b/homebridge/accessories/smart-elife/air-conditioner.ts
@@ -548,7 +548,8 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
             for(const device of devices) {
                 const active = device.op["status"] === "on";
                 const currentTemperature = device.op["current_temp"] ? Number(device.op["current_temp"]) : MIN_TEMPERATURE || MIN_TEMPERATURE;
-                const desiredTemperature = device.op["desired_temp"] ? Number(device.op["desired_temp"]) : MIN_TEMPERATURE || MIN_TEMPERATURE;
+                const targetTemperature = device.op["desired_temp"] ?? device.op["set_temp"];
+                const desiredTemperature = targetTemperature ? Number(targetTemperature) : MIN_TEMPERATURE || MIN_TEMPERATURE;
                 const rotationSpeed = active ? device.op["wind_speed"] as RotationSpeed || RotationSpeed.OFF : RotationSpeed.OFF;
                 const operationMode = device.op["mode"] as Mode || Mode.AUTO;
                 const accessory = this.addOrGetAccessory({

--- a/homebridge/accessories/smart-elife/heater.ts
+++ b/homebridge/accessories/smart-elife/heater.ts
@@ -116,7 +116,8 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
             for(const device of devices) {
                 const active = device.op["status"] === "on";
                 const currentTemperature = device.op["current_temp"] ? Number(device.op["current_temp"]) : MIN_TEMPERATURE || MIN_TEMPERATURE;
-                const desiredTemperature = device.op["desired_temp"] ? Number(device.op["desired_temp"]) : MIN_TEMPERATURE || MIN_TEMPERATURE;
+                const targetTemperature = device.op["desired_temp"] ?? device.op["set_temp"];
+                const desiredTemperature = targetTemperature ? Number(targetTemperature) : MIN_TEMPERATURE || MIN_TEMPERATURE;
                 const accessory = this.addOrGetAccessory({
                     deviceId: device.deviceId,
                     deviceType: device.deviceType,


### PR DESCRIPTION
## Summary
- Read Smart eLife HVAC target temperatures from `set_temp` when `desired_temp` is not present
- Apply the fallback to both air conditioners and heaters
- Preserve existing `desired_temp` behavior for compatible responses

## Why
Smart eLife device operations can report target temperatures as `set_temp`. When `desired_temp` is absent, the plugin currently falls back to the minimum temperature, which makes HomeKit/Home Assistant show 18 °C for air conditioners even when the actual target temperature is different.

Observed Smart eLife operation shape:
```json
{
  "current_temp": "25",
  "set_temp": "26",
  "status": "on"
}
```

## Validation
- Ran `npm ci` with Node v24.14.0
- Ran `npm run build`
- Verified locally that Home Assistant target temperatures now reflect Smart eLife `set_temp` values instead of falling back to 18 °C