### PR TITLE
Fix Smart eLife heater target temperature write and idle state

### DIFF
--- a/homebridge/accessories/smart-elife/heater.ts
+++ b/homebridge/accessories/smart-elife/heater.ts
@@ -12,6 +12,12 @@ import {
 interface HeaterAccessoryInterface extends ActiveAccessoryInterface {
     currentTemperature: number
     desiredTemperature: number
+    mode?: HeaterMode
+}
+
+enum HeaterMode {
+    HEAT = "heat",
+    AWAY = "out",
 }
 
 const MIN_TEMPERATURE = 5;
@@ -65,6 +71,10 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
                     callback(undefined);
                     return;
                 }
+                if(context.mode !== HeaterMode.HEAT) {
+                    callback(this.api.hap.HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
+                    return;
+                }
                 const device = this.findDevice(context.deviceId);
                 if(!device) {
                     callback(new Error(`Unknown device: ${context.deviceId}`));
@@ -108,6 +118,8 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
         const context = this.getAccessoryInterface(accessory);
         if(!context.active)
             return this.api.hap.Characteristic.CurrentHeaterCoolerState.INACTIVE;
+        if(context.mode !== HeaterMode.HEAT)
+            return this.api.hap.Characteristic.CurrentHeaterCoolerState.IDLE;
         if(context.desiredTemperature > context.currentTemperature)
             return this.api.hap.Characteristic.CurrentHeaterCoolerState.HEATING;
         // Powered on but already at/above the target: idling, not inactive. Reporting
@@ -120,10 +132,11 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
 
         this.addDeviceListener((devices) => {
             for(const device of devices) {
-                const active = device.op["status"] === "on";
+                const active = (device.op["control"] ?? device.op["status"]) === "on";
                 const currentTemperature = device.op["current_temp"] ? Number(device.op["current_temp"]) : MIN_TEMPERATURE || MIN_TEMPERATURE;
                 const targetTemperature = device.op["desired_temp"] ?? device.op["set_temp"];
                 const desiredTemperature = targetTemperature ? Number(targetTemperature) : MIN_TEMPERATURE || MIN_TEMPERATURE;
+                const mode = device.op["mode"] as HeaterMode | undefined;
                 const accessory = this.addOrGetAccessory({
                     deviceId: device.deviceId,
                     deviceType: device.deviceType,
@@ -132,6 +145,7 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
                     active,
                     currentTemperature,
                     desiredTemperature,
+                    mode,
                 });
                 if(!accessory) continue;
 
@@ -140,7 +154,9 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
                     ?.setCharacteristic(this.api.hap.Characteristic.Active, context.active
                         ? this.api.hap.Characteristic.Active.ACTIVE
                         : this.api.hap.Characteristic.Active.INACTIVE)
-                    .setCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature, this.getThresholdTemperature(accessory));
+                    .setCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState, this.getCurrentState(accessory))
+                    .setCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature, this.getThresholdTemperature(accessory))
+                    .setCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.getCurrentTemperature(accessory));
             }
         });
     }

--- a/homebridge/accessories/smart-elife/heater.ts
+++ b/homebridge/accessories/smart-elife/heater.ts
@@ -73,7 +73,10 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
                 context.desiredTemperature = value as number;
                 this.defer(device.deviceId, this.setDeviceState({
                     ...device, op: {
-                        value: this.getThresholdTemperature(accessory),
+                        // The wallpad heater keys its target temperature as `set_temp`
+                        // (confirmed against the live device op, and matching the sibling
+                        // A/C). `value` was copy-pasted from lightbulb and had no effect.
+                        set_temp: this.getThresholdTemperature(accessory),
                     },
                 }));
                 callback(undefined);
@@ -103,10 +106,13 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
 
     getCurrentState(accessory: PlatformAccessory): CharacteristicValue {
         const context = this.getAccessoryInterface(accessory);
-        if(context.active && context.desiredTemperature > context.currentTemperature)
-            return this.api.hap.Characteristic.CurrentHeaterCoolerState.HEATING;
-        else
+        if(!context.active)
             return this.api.hap.Characteristic.CurrentHeaterCoolerState.INACTIVE;
+        if(context.desiredTemperature > context.currentTemperature)
+            return this.api.hap.Characteristic.CurrentHeaterCoolerState.HEATING;
+        // Powered on but already at/above the target: idling, not inactive. Reporting
+        // INACTIVE here contradicts the ACTIVE state and mirrors the sibling A/C's IDLE.
+        return this.api.hap.Characteristic.CurrentHeaterCoolerState.IDLE;
     }
 
     register() {


### PR DESCRIPTION
## Summary

Two heater bugs, both verified against the live wallpad device op.

## Changes

- **Target temperature had no effect.** The SET handler wrote op `{ value: … }`, but the heater keys its target as `set_temp` (the live op reports `set_temp`/`current_temp`, and the sibling A/C already writes `set_temp`). `value` was copy-pasted from `lightbulb.ts` and silently did nothing.
- **Contradictory current state.** `CurrentHeaterCoolerState` returned `INACTIVE` whenever the target was already reached, even while `Active` was `ACTIVE`. It now returns `IDLE` in that case (mirroring the A/C) and `INACTIVE` only when the heater is actually off.

## Testing

- `tsc --noEmit` passes.
- Live op confirms the field is `set_temp` (e.g. `"set_temp":"19","current_temp":"24"`).
