### PR TITLE
Fix Smart eLife indoor air quality reading “Unknown”, and harden polling.

### DIFF
--- a/homebridge/accessories/smart-elife/indoor-air-quality.ts
+++ b/homebridge/accessories/smart-elife/indoor-air-quality.ts
@@ -30,6 +30,7 @@ enum AirQuality {
     BAD = "bad",
     NORMAL = "normal",
     GOOD = "good",
+    UNKNOWN = "unknown",
 }
 
 namespace AirQuality {
@@ -39,15 +40,22 @@ namespace AirQuality {
             case "bad": return AirQuality.BAD;
             case "normal": return AirQuality.NORMAL;
             case "good": return AirQuality.GOOD;
-            default: throw new Error(`Prohibited air quality: ${quality}`);
+            // Unexpected `css` value: degrade gracefully instead of throwing, so one odd
+            // reading can't abort the whole polling cycle (and the humidity aggregation
+            // the A/C dehumidifier depends on).
+            default: return AirQuality.UNKNOWN;
         }
     }
-    export function score(quality: AirQuality): number {
+    // Maps a sensor grade to a HomeKit `Characteristic.AirQuality` value:
+    //   0 = UNKNOWN, 1 = EXCELLENT, 2 = GOOD, 3 = FAIR, 4 = INFERIOR, 5 = POOR.
+    // Note: `good` must map to EXCELLENT (1), NOT 0 — 0 renders as "Unknown" in Home.
+    export function toHomeKitAirQuality(quality: AirQuality): number {
         switch(quality) {
-            case AirQuality.VERY_BAD: return 5;
-            case AirQuality.BAD: return 3;
-            case AirQuality.NORMAL: return 1;
-            case AirQuality.GOOD: return 0;
+            case AirQuality.GOOD: return 1;      // EXCELLENT
+            case AirQuality.NORMAL: return 2;    // GOOD
+            case AirQuality.BAD: return 4;       // INFERIOR
+            case AirQuality.VERY_BAD: return 5;  // POOR
+            case AirQuality.UNKNOWN: return 0;   // UNKNOWN
         }
     }
 }
@@ -67,11 +75,15 @@ export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQu
     }
 
     getAirQuality(context: IndoorAirQualityAccessoryInterface): CharacteristicValue {
-        const q = [ context.pm10, context.pm2_5, context.co2, context.vocs ]
-            .map((q) => AirQuality.score(q.quality));
-        const sum = q.reduce((acc, n) => acc + n, 0);
-        const avg = sum / q.length;
-        return parseInt(avg.toFixed(0)) as CharacteristicValue;
+        // Overall air quality reflects the worst-graded pollutant (the standard HomeKit
+        // convention), ignoring UNKNOWN(0) grades unless every pollutant is unknown.
+        const values = [ context.pm10, context.pm2_5, context.co2, context.vocs ]
+            .map((q) => AirQuality.toHomeKitAirQuality(q.quality))
+            .filter((v) => v > 0);
+        if(values.length === 0) {
+            return 0 as CharacteristicValue; // UNKNOWN
+        }
+        return Math.max(...values) as CharacteristicValue;
     }
 
     async fetchAirQuality() {
@@ -81,13 +93,13 @@ export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQu
         this.skippedFirstPollingMessage = true;
 
         const response = await this.client.sendHttpJson("/monitoring/getAirList.ajax", { location: "all" });
-        if(!response["data"]) {
-            const message = response["result"]["errorMessage"].replace(/(<br\/>)/gi, " ");
-            const code = response["result"]["status"];
+        if(!response || !response["data"]) {
+            const message = (response?.["result"]?.["errorMessage"] ?? "unknown reason").replace(/(<br\/>)/gi, " ");
+            const code = response?.["result"]?.["status"] ?? "";
             this.log.warn("Devices (%s) not found: (%s) %s", this.deviceType.toString(), code, message);
             return;
         }
-        const devices = response["data"]["list"];
+        const devices = response["data"]["list"] || [];
         let humiditySum = 0;
         let humidityCount = 0;
         let index = 0;
@@ -98,24 +110,30 @@ export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQu
             const device = this.findDevice(deviceId);
             if(!device) continue;
 
-            const humidity = Number(info["humi"]);
-            if(Number.isFinite(humidity)) {
-                humiditySum += humidity;
-                humidityCount += 1;
-            }
+            // Isolate per-device parsing so one malformed reading cannot abort the rest of
+            // the cycle (including the humidity aggregation below).
+            try {
+                const humidity = Number(info["humi"]);
+                if(Number.isFinite(humidity)) {
+                    humiditySum += humidity;
+                    humidityCount += 1;
+                }
 
-            this.addOrGetAccessory({
-                deviceId: device.deviceId,
-                deviceType: device.deviceType,
-                displayName: device.displayName,
-                init: true,
-                pm10: { density: info["pm10"]["value"], quality: AirQuality.parse(info["pm10"]["css"]) },
-                pm2_5: { density: info["pm25"]["value"], quality: AirQuality.parse(info["pm25"]["css"]) },
-                co2: { density: info["co2"]["value"], quality: AirQuality.parse(info["co2"]["css"]) },
-                vocs: { density: info["vocs"]["value"], quality: AirQuality.parse(info["vocs"]["css"]) },
-                temperature: Number(info["temp"]),
-                humidity,
-            });
+                this.addOrGetAccessory({
+                    deviceId: device.deviceId,
+                    deviceType: device.deviceType,
+                    displayName: device.displayName,
+                    init: true,
+                    pm10: { density: Number(info["pm10"]["value"]), quality: AirQuality.parse(info["pm10"]["css"]) },
+                    pm2_5: { density: Number(info["pm25"]["value"]), quality: AirQuality.parse(info["pm25"]["css"]) },
+                    co2: { density: Number(info["co2"]["value"]), quality: AirQuality.parse(info["co2"]["css"]) },
+                    vocs: { density: Number(info["vocs"]["value"]), quality: AirQuality.parse(info["vocs"]["css"]) },
+                    temperature: Number(info["temp"]),
+                    humidity,
+                });
+            } catch(e: any) {
+                this.log.warn("Could not parse air-quality reading for %s: %s", device.displayName, e?.message || e);
+            }
         }
         if(humidityCount > 0) {
             setGlobalIndoorRelativeHumidity(humiditySum / humidityCount);
@@ -173,7 +191,14 @@ export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQu
     register() {
         super.register();
 
-        setTimeout(this.fetchAirQuality.bind(this), 1000); // immediate run (asynchronously)
-        setInterval(this.fetchAirQuality.bind(this), INDOOR_AIR_QUALITY_POLLING_INTERVAL_MILLISECONDS);
+        // Wrap the scheduled polls so a rejected fetch (network/CSRF failure) is logged
+        // instead of surfacing as an unhandled promise rejection.
+        const run = () => {
+            this.fetchAirQuality().catch((e: any) => {
+                this.log.warn("Air-quality polling failed: %s", e?.message || e);
+            });
+        };
+        setTimeout(run, 1000); // immediate run (asynchronously)
+        setInterval(run, INDOOR_AIR_QUALITY_POLLING_INTERVAL_MILLISECONDS);
     }
 }


### PR DESCRIPTION
# Summary

<img width="1320" height="655" alt="IMG_8791" src="https://github.com/user-attachments/assets/1500763e-5655-4d47-9a76-258b617385f4" />
<img width="1320" height="1672" alt="IMG_8792" src="https://github.com/user-attachments/assets/03b451be-c599-4c6a-89b4-0ed9e8b7e91f" />
<img width="1320" height="2682" alt="IMG_8793" src="https://github.com/user-attachments/assets/ed9cfa74-158b-49bd-8547-2ecddd67c82e" />

The indoor air-quality sensor showed **Unknown** in the Home app even when every pollutant was graded *good*, and a single malformed reading could abort the whole polling cycle.

# Root cause

`AirQuality.score()` mapped `good → 0` and `getAirQuality()` returned the averaged score **directly** as the HomeKit `AirQuality` value. HomeKit reads `0` as `UNKNOWN` (1 = EXCELLENT … 5 = POOR), so an all-*good* sensor collapsed to *Unknown*. Confirmed against the live wallpad, which reports `css: "good"` for every pollutant.

# Changes

- Map each grade straight onto HomeKit's scale (`good → EXCELLENT(1)` … `very-bad → POOR(5)`) and report the **worst** pollutant instead of an average, so the best state no longer collapses to `UNKNOWN`.
- `AirQuality.parse()` degrades an unexpected `css` to `UNKNOWN` instead of throwing.
- Parse each device reading inside `try/catch`, so one bad reading cannot abort the rest of the cycle (or the humidity aggregation the A/C dehumidifier depends on).
- Guard the error-response path and add `.catch` to the scheduled polls to prevent unhandled promise rejections.

# Testing

- `tsc --noEmit` passes; full `npm run build` passes.
- Verified against live device output: densities are numeric and `css` is `"good"`; the sensor now reads *Excellent* instead of *Unknown*.
