### PR TITLE
Release v1.5.7 beta

### DIFF
--- a/logs/v1.5.7.md
+++ b/logs/v1.5.7.md
@@ -34,3 +34,4 @@ v1.5.7 — Improve accessories, cameras, configuration, and security
   - tar 7.5.11 → 7.5.21 [#162](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/162), [#170](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/170)
   - brace-expansion 1.1.12 → 1.1.16 [#169](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/169)
   - rimraf 3.0.2 → 6.1.3 and brace-expansion 1.1.16 → 5.0.8 to fix dependency audit failures
+  - brace-expansion 5.0.8 → 5.0.9 to fix [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)

--- a/logs/v1.5.7.md
+++ b/logs/v1.5.7.md
@@ -1,4 +1,4 @@
-v1.5.7 — Improve accessories, configuration, and security
+v1.5.7 — Improve accessories, cameras, configuration, and security
 # CHANGELOGS
 
 - Add Smart eLife smart door lock accessory ([#172](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/172))
@@ -13,6 +13,17 @@ v1.5.7 — Improve accessories, configuration, and security
 - Support the new Smart eLife push payload format, add a communal door motion sensor, and expose the smart door as a read-only contact sensor ([#183](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/183))
 - Fix falsy configuration values disabling every accessory, unlock the advanced editor after refresh failures, and make Daelim device fetching deterministic ([#185](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/185))
 - Report disabled Smart eLife devices only once instead of on every poll ([#188](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/188))
+- Repair damaged accessory caches and prevent a missing information service from crash-looping child bridges ([#191](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/191))
+- Restore doorbell visitor image routing after the Smart eLife push payload change and contain listener failures ([#193](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/193))
+- Unify Korean terminology and help text across the configuration UI ([#194](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/194))
+- Add optional One Pass live view for the household front door camera with snapshot fallback ([#195](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/195))
+  - Disabled by default; each live view opens an interphone call that is exclusive with the phone app
+- Add an opt-in setting to merge numbered Smart eLife light groups into one level-stepped Lightbulb accessory ([#196](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/196))
+  - Enabling or disabling the setting replaces the affected accessories, so their scenes and automations must be recreated
+- Fix camera streams and snapshots when HomeKit requests a resolution smaller than the source ([#199](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/199))
+- Expose Smart eLife vent operation modes as HomeKit switches ([#200](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/200))
+- Refuse HTTP and WebSocket device reports that belong to another household ([#201](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/201))
+- Rework Smart eLife air conditioner gestures around device confirmations instead of fixed timers ([#203](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/203))
 - Refresh Smart eLife complex data ([#163](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/163), [#164](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/164), [#165](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/165), [#166](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/166), [#187](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/187))
 - Inline Smart eLife dong values in generated complexes ([#167](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/167))
 - Harden npm supply chain checks with package signature audits and publish provenance

--- a/logs/v1.5.7.md
+++ b/logs/v1.5.7.md
@@ -1,4 +1,4 @@
-v1.5.7 — Improve Smart eLife accessories and security
+v1.5.7 — Improve accessories, configuration, and security
 # CHANGELOGS
 
 - Add Smart eLife smart door lock accessory ([#172](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/172))
@@ -7,6 +7,9 @@ v1.5.7 — Improve Smart eLife accessories and security
 - Fix Smart eLife vent dropping the selected fan speed when auto-powered on ([#174](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/174))
 - Fix Smart eLife indoor air quality readings showing `Unknown` and harden polling ([#175](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/175))
 - Fix Smart eLife VOC density exceeding HomeKit's 1000 µg/m³ maximum ([#177](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/177))
+- Fix Smart eLife cooktop lock state not being reflected back to HomeKit ([#181](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/181))
+- Support the new Smart eLife push payload format, add a communal door motion sensor, and expose the smart door as a read-only contact sensor ([#183](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/183))
+- Fix falsy configuration values disabling every accessory, unlock the advanced editor after refresh failures, and make Daelim device fetching deterministic ([#185](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/185))
 - Refresh Smart eLife complex data ([#163](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/163), [#164](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/164), [#165](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/165), [#166](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/166))
 - Inline Smart eLife dong values in generated complexes ([#167](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/167))
 - Harden npm supply chain checks with package signature audits and publish provenance

--- a/logs/v1.5.7.md
+++ b/logs/v1.5.7.md
@@ -26,6 +26,7 @@ v1.5.7 — Improve accessories, cameras, configuration, and security
 - Rework Smart eLife air conditioner gestures around device confirmations instead of fixed timers ([#203](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/203))
 - Polish user-facing Korean wording and README feature descriptions ([#205](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/205))
 - Reflect wallpad state without invoking HomeKit SET handlers, preventing reflected values from being sent back as commands ([#206](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/206))
+- Add change-aware debug logging for successful Smart eLife accessory reports and motion-event lifecycles ([#207](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/207))
 - Refresh Smart eLife complex data ([#163](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/163), [#164](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/164), [#165](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/165), [#166](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/166), [#187](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/187))
 - Inline Smart eLife dong values in generated complexes ([#167](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/167))
 - Harden npm supply chain checks with package signature audits and publish provenance

--- a/logs/v1.5.7.md
+++ b/logs/v1.5.7.md
@@ -7,10 +7,13 @@ v1.5.7 — Improve accessories, configuration, and security
 - Fix Smart eLife vent dropping the selected fan speed when auto-powered on ([#174](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/174))
 - Fix Smart eLife indoor air quality readings showing `Unknown` and harden polling ([#175](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/175))
 - Fix Smart eLife VOC density exceeding HomeKit's 1000 µg/m³ maximum ([#177](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/177))
+- Rework the Smart eLife air conditioner as a HeaterCooler and Fanv2 hybrid with mode-aware temperature and fan speed controls ([#179](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/179))
+  - Automations and scenes bound to the former AirPurifier service must be recreated against the new Fanv2 service
 - Fix Smart eLife cooktop lock state not being reflected back to HomeKit ([#181](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/181))
 - Support the new Smart eLife push payload format, add a communal door motion sensor, and expose the smart door as a read-only contact sensor ([#183](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/183))
 - Fix falsy configuration values disabling every accessory, unlock the advanced editor after refresh failures, and make Daelim device fetching deterministic ([#185](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/185))
-- Refresh Smart eLife complex data ([#163](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/163), [#164](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/164), [#165](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/165), [#166](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/166))
+- Report disabled Smart eLife devices only once instead of on every poll ([#188](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/188))
+- Refresh Smart eLife complex data ([#163](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/163), [#164](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/164), [#165](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/165), [#166](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/166), [#187](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/187))
 - Inline Smart eLife dong values in generated complexes ([#167](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/167))
 - Harden npm supply chain checks with package signature audits and publish provenance
 - Node.js deps security updates
@@ -19,3 +22,4 @@ v1.5.7 — Improve accessories, configuration, and security
   - form-data 3.0.4 → 3.0.5 [#161](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/161)
   - tar 7.5.11 → 7.5.21 [#162](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/162), [#170](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/170)
   - brace-expansion 1.1.12 → 1.1.16 [#169](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/169)
+  - rimraf 3.0.2 → 6.1.3 and brace-expansion 1.1.16 → 5.0.8 to fix dependency audit failures

--- a/logs/v1.5.7.md
+++ b/logs/v1.5.7.md
@@ -24,6 +24,8 @@ v1.5.7 — Improve accessories, cameras, configuration, and security
 - Expose Smart eLife vent operation modes as HomeKit switches ([#200](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/200))
 - Refuse HTTP and WebSocket device reports that belong to another household ([#201](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/201))
 - Rework Smart eLife air conditioner gestures around device confirmations instead of fixed timers ([#203](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/203))
+- Polish user-facing Korean wording and README feature descriptions ([#205](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/205))
+- Reflect wallpad state without invoking HomeKit SET handlers, preventing reflected values from being sent back as commands ([#206](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/206))
 - Refresh Smart eLife complex data ([#163](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/163), [#164](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/164), [#165](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/165), [#166](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/166), [#187](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/187))
 - Inline Smart eLife dong values in generated complexes ([#167](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/167))
 - Harden npm supply chain checks with package signature audits and publish provenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.7-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daelim-smarthome",
-      "version": "1.5.7-beta.1",
+      "version": "1.5.7-beta.2",
       "funding": [
         {
           "type": "paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.6",
+  "version": "1.5.7-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daelim-smarthome",
-      "version": "1.5.6",
+      "version": "1.5.7-beta.0",
       "funding": [
         {
           "type": "paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.3",
+  "version": "1.5.7-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daelim-smarthome",
-      "version": "1.5.7-beta.3",
+      "version": "1.5.7-beta.4",
       "funding": [
         {
           "type": "paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.0",
+  "version": "1.5.7-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daelim-smarthome",
-      "version": "1.5.7-beta.0",
+      "version": "1.5.7-beta.1",
       "funding": [
         {
           "type": "paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.2",
+  "version": "1.5.7-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daelim-smarthome",
-      "version": "1.5.7-beta.2",
+      "version": "1.5.7-beta.3",
       "funding": [
         {
           "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge DL E&C Smart Home",
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.0",
+  "version": "1.5.7-beta.1",
   "description": "A third-party Homebridge platform plugin for DL E&C SmartHome",
   "main": "dist/homebridge/daelim-smarthome-platform.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge DL E&C Smart Home",
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.6",
+  "version": "1.5.7-beta.0",
   "description": "A third-party Homebridge platform plugin for DL E&C SmartHome",
   "main": "dist/homebridge/daelim-smarthome-platform.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge DL E&C Smart Home",
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.3",
+  "version": "1.5.7-beta.4",
   "description": "A third-party Homebridge platform plugin for DL E&C SmartHome",
   "main": "dist/homebridge/daelim-smarthome-platform.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge DL E&C Smart Home",
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.1",
+  "version": "1.5.7-beta.2",
   "description": "A third-party Homebridge platform plugin for DL E&C SmartHome",
   "main": "dist/homebridge/daelim-smarthome-platform.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge DL E&C Smart Home",
   "name": "homebridge-daelim-smarthome",
-  "version": "1.5.7-beta.2",
+  "version": "1.5.7-beta.3",
   "description": "A third-party Homebridge platform plugin for DL E&C SmartHome",
   "main": "dist/homebridge/daelim-smarthome-platform.js",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump the package version to `1.5.7-beta.3` for the beta release.
- Add the Smart eLife smart door lock accessory ([#172](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/172)).
- Fix Smart eLife elevator release, heater state/temperature writes, vent fan-speed retention, and indoor-air-quality polling/readings ([#171](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/171), [#173](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/173), [#174](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/174), [#175](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/175), [#177](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/177)).
- Rework the Smart eLife air conditioner as a HeaterCooler and Fanv2 hybrid, then replace fixed gesture timers with device-report confirmations ([#179](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/179), [#203](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/203)).
  - Automations and scenes bound to the former AirPurifier service must be recreated against the new Fanv2 service.
- Fix Smart eLife cooktop lock state synchronization with HomeKit ([#181](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/181)).
- Support the new Smart eLife push payload format, add a communal door motion sensor, expose the smart door as a read-only contact sensor, and restore visitor image routing ([#183](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/183), [#193](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/193)).
- Fix falsy configuration values disabling every accessory, unlock the advanced editor after refresh failures, and make Daelim device fetching deterministic ([#185](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/185)).
- Report disabled Smart eLife devices only once instead of on every poll ([#188](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/188)).
- Repair damaged accessory caches and prevent missing information services from crash-looping child bridges ([#191](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/191)).
- Unify Korean terminology and help text across the configuration UI ([#194](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/194)).
- Add optional One Pass live view for the household front door camera with snapshot fallback ([#195](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/195)).
  - Disabled by default; each live view opens an interphone call that is exclusive with the phone app.
- Add an opt-in setting to merge numbered Smart eLife light groups into one level-stepped Lightbulb accessory ([#196](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/196)).
  - Enabling or disabling the setting replaces the affected accessories, so their scenes and automations must be recreated.
- Fix camera streams and snapshots when HomeKit requests a resolution smaller than the source ([#199](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/199)).
- Expose Smart eLife vent operation modes as HomeKit switches ([#200](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/200)).
- Refuse HTTP and WebSocket device reports that belong to another household ([#201](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/201)).
- Polish user-facing Korean wording and README feature descriptions ([#205](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/205)).
- Reflect wallpad state without invoking HomeKit SET handlers, preventing reflected values from being sent back as commands ([#206](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/206)).
- Add change-aware debug logging for successful Smart eLife accessory reports and motion-event lifecycles, without changing behavior ([#207](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/207)).
- Refresh Smart eLife complex data and compact generated dong values ([#163](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/163), [#164](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/164), [#165](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/165), [#166](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/166), [#167](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/167), [#187](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/187)).
- Harden npm supply-chain checks with signature audits, pinned dependencies, and publish provenance.
- Update axios, ws, form-data, tar, brace-expansion, and rimraf dependencies, including brace-expansion 5.0.9 for [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) ([#159](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/159), [#160](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/160), [#161](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/161), [#162](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/162), [#168](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/168), [#169](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/169), [#170](https://github.com/OrigamiDream/homebridge-daelim-smarthome/pull/170)).

## Validation

- `npm run build` — passed
- `git diff --check origin/main..origin/v1.5.7-beta` — passed
- `npm audit --audit-level=high` — passed (0 vulnerabilities)
- Confirmed the PR changes only the v1.5.7 release notes and package metadata for `1.5.7-beta.3`.

## Release notes

See `logs/v1.5.7.md` for the complete changelog since v1.5.6.