### PR TITLE
Fix Smart eLife VOC density exceeding HomeKit's 1000 µg/m³ maximum

### DIFF
--- a/homebridge/accessories/smart-elife/indoor-air-quality.ts
+++ b/homebridge/accessories/smart-elife/indoor-air-quality.ts
@@ -62,6 +62,20 @@ namespace AirQuality {
 
 const INDOOR_AIR_QUALITY_POLLING_INTERVAL_MILLISECONDS = 60 * 1000;
 
+// Apple-defined density characteristics (PM10Density, PM2_5Density, VOCDensity) only
+// accept 0–1000 µg/m³, but the wall pad grades TVOC on its own 0–1500 scale (the feed's
+// `max` field; readings up to ~1944 observed) with no unit metadata, so values above
+// 1000 arrive routinely. Clamp into the valid range instead of raising maxValue via
+// setProps; the air-quality grade shown in Home comes from `css`, not the raw density.
+const HOMEKIT_DENSITY_MAX = 1000;
+
+function clampDensity(density: number): number {
+    if(!Number.isFinite(density)) {
+        return 0;
+    }
+    return Math.max(0, Math.min(HOMEKIT_DENSITY_MAX, density));
+}
+
 export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQualityAccessoryInterface> {
 
     private skippedFirstPollingMessage: boolean = false;
@@ -151,19 +165,19 @@ export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQu
             .getCharacteristic(this.api.hap.Characteristic.PM10Density)
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                callback(undefined, context.pm10.density);
+                callback(undefined, clampDensity(context.pm10.density));
             });
         this.getService(accessory, this.api.hap.Service.AirQualitySensor)
             .getCharacteristic(this.api.hap.Characteristic.PM2_5Density)
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                callback(undefined, context.pm2_5.density);
+                callback(undefined, clampDensity(context.pm2_5.density));
             });
         this.getService(accessory, this.api.hap.Service.AirQualitySensor)
             .getCharacteristic(this.api.hap.Characteristic.VOCDensity)
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                callback(undefined, context.vocs.density);
+                callback(undefined, clampDensity(context.vocs.density));
             });
     }
 


### PR DESCRIPTION
# Summary

Smart eLife indoor air-quality accessories forwarded the wall pad's raw TVOC reading straight to HomeKit's `VOCDensity` characteristic, which only accepts 0–1000 µg/m³. Readings above 1000 arrive routinely, so Homebridge logged an illegal-value warning every few minutes. Densities supplied to HomeKit are now clamped into the valid range.

# Root cause

The `VOCDensity` / `PM10Density` / `PM2_5Density` GET handlers in `homebridge/accessories/smart-elife/indoor-air-quality.ts` returned `context.*.density` unmodified. The wall pad grades TVOC on its own 0–1500 scale (the feed's `max` field) with no unit metadata: a live query of `/monitoring/getAirList.ajax` returned `vocs: { value: 1248, max: 1500, css: "bad" }`, and readings up to ~1944 were observed in runtime logs. Values above the Apple-defined 1000 maximum are therefore normal for this feed, and every HomeKit read of such a value triggered the characteristic warning.

# Changes

- Added a `clampDensity()` helper that clamps densities into 0–1000 and maps non-finite values (malformed feed data) to 0.
- Applied it to the VOC, PM10, and PM2.5 GET handlers. The PM densities share the same Apple-defined 0–1000 maximum and come from the same wall-pad feed, so they get the same guard. Clamping happens at read time only; the raw reading stored in the accessory context is untouched, which also covers out-of-range values restored from the accessory cache after a restart.
- Rejected alternatives: raising `maxValue` via `setProps` (nonstandard mutation of an Apple-defined characteristic), converting units (the feed has no unit metadata, and its grade thresholds line up with common TVOC µg/m³ scales, so the value is likely µg/m³ already), and rescaling by the feed's `max` (the reported number would no longer be a density).
- The air-quality grade shown in the Home app is derived from the feed's own `css` grade field, so it is unaffected by the clamp.

# Testing

- `npm run build` type check passes.
- Queried the live backend with the plugin's own client and confirmed the feed shape: `vocs: { value: 1248, max: 1500, css: "bad" }` — values above 1000 with no unit field.
- Not yet verified on a running Homebridge instance; the warning should stop since values supplied to HomeKit are now always within the allowed range.