### PR TITLE
Rework Smart eLife air conditioner as a Fanv2 hybrid accessory

### DIFF
--- a/homebridge/accessories/smart-elife/air-conditioner.ts
+++ b/homebridge/accessories/smart-elife/air-conditioner.ts
@@ -7,13 +7,25 @@ import {
     PlatformAccessory, Service
 } from "homebridge";
 import {DeviceType, SmartELifeConfig} from "../../../core/interfaces/smart-elife-config";
-import Accessories, {AccessoryInterface, ServiceType} from "./accessories";
+import Accessories, {AccessoryInterface} from "./accessories";
 import {getGlobalIndoorRelativeHumidity} from "./indoor-air-quality-cache";
 
 interface AirConditionerInterface extends AccessoryInterface {
     active: boolean
     mode: Mode
     rotationSpeed: RotationSpeed
+
+    /**
+     * Last manual wind speed (LOW/MIDDLE/HIGH only). Preserved across auto/off so the
+     * slider can restore the previous manual speed when leaving wallpad-managed states.
+     */
+    lastManualRotationSpeed: RotationSpeed
+
+    /**
+     * Last climate mode (AUTO/COOLING only). HeaterCooler power-on returns to this mode.
+     */
+    lastClimateMode: Mode
+
     currentTemperature: number
     desiredTemperature: number
 }
@@ -23,26 +35,79 @@ enum RotationSpeed {
     LOW = "low",
     MIDDLE = "middle",
     HIGH = "high",
+    AUTO = "auto", // Wallpad-managed wind. Only valid while in cooling mode.
 }
 
 enum Mode {
-    AUTO = "auto", // In auto mode, adjusting RotationSpeed is disallowed, but temperature.
-    COOLING = "cool", // In cooling mode, adjusting RotationSpeed and temperature is allowed.
-    DEHUMIDIFYING = "dehumi", // In dehumidifying mode, adjusting RotationSpeed and temperature is disallowed.
-    FAN = "fan", // In fan mode, setting RotationSpeed as auto and adjusting temperature is disallowed.
+    AUTO = "auto", // In auto mode, adjusting temperature is allowed but the wind is wallpad-managed.
+    COOLING = "cool", // In cooling mode, adjusting temperature and wind (incl. "auto") is allowed.
+    DEHUMIDIFYING = "dehumi", // In dehumidifying mode, nothing but the power is adjustable.
+    FAN = "fan", // In fan mode, adjusting wind (except "auto") is allowed but not temperature.
 }
 
 const ROTATION_SPEED_STEP = 100 / 3.0;
 const MIN_TEMPERATURE = 18;
 const MAX_TEMPERATURE = 30;
 
+/**
+ * Per-device, never-persisted bookkeeping. Holds three unrelated concerns keyed off the
+ * same device:
+ *  - the temperature handle gesture (mirror + pending write, resolved in scheduleSync),
+ *  - the command guard that suppresses stale pre-command state pushes, and
+ *  - the temperature re-assert guard that forces our setpoint past the wallpad's own
+ *    stored per-mode value.
+ * See applyWallPadState and scheduleSync for how these interact with incoming pushes.
+ */
+interface TemperatureGesture {
+    coolMirror?: number
+    pendingCool?: number
+    timer?: NodeJS.Timeout
+    parkTimer?: NodeJS.Timeout
+
+    // Command guard: the power/mode we last commanded and expect the wallpad to confirm.
+    pendingPower?: boolean
+    pendingMode?: Mode
+    pendingSince?: number
+
+    // Temperature re-assert guard: the setpoint we insist on and its deadline.
+    tempGuardTarget?: number
+    tempGuardUntil?: number
+    lastReassertAt?: number
+}
+
+// Long enough that both writes of one Home app gesture (the moved handle plus the
+// app's rewrite of the untouched one) land in the same window, short enough that
+// the follower handle visibly snaps over right after the drag.
+const GESTURE_WINDOW_MILLISECONDS = 120;
+
+// The Home app tends to ignore a correction that contradicts its own write for a few
+// seconds, and once our value is back at the park further syncs emit no event (no
+// change) — so the parked handle gets a late forced notification after this delay.
+const LATE_PARK_PUSH_MILLISECONDS = 2500;
+
+// After a command, ignore pushes that still carry the pre-command power/mode for up to
+// this long (or until the wallpad confirms our power+mode, whichever comes first). The
+// wallpad reflects a control op only after a few seconds and would otherwise fight the
+// optimistic UI.
+const COMMAND_GUARD_MILLISECONDS = 7000;
+
+// The wallpad drops a set_temp bundled with a mode change and keeps its own stored
+// per-mode setpoint. Hold the displayed temperature at our target and re-send a
+// standalone set_temp until the wallpad reports it, capped at this window.
+const TEMP_GUARD_MILLISECONDS = 10000;
+
+// Minimum spacing between standalone set_temp re-assert commands within the guard window.
+const REASSERT_THROTTLE_MILLISECONDS = 1000;
+
 export default class AirConditionerAccessories extends Accessories<AirConditionerInterface> {
+
+    private readonly temperatureGestures: Record<string, TemperatureGesture> = {};
 
     constructor(log: Logging, api: API, config: SmartELifeConfig) {
         super(log, api, config, DeviceType.AIR_CONDITIONER, [
             api.hap.Service.HeaterCooler,
+            api.hap.Service.Fanv2,
             api.hap.Service.HumidifierDehumidifier,
-            api.hap.Service.AirPurifier,
         ]);
     }
 
@@ -55,48 +120,307 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
 
     private rotationSpeedToHomebridge(rotationSpeed: RotationSpeed): number {
         switch (rotationSpeed) {
-            case RotationSpeed.OFF: return 0;
             case RotationSpeed.LOW: return ROTATION_SPEED_STEP;
             case RotationSpeed.MIDDLE: return ROTATION_SPEED_STEP * 2;
             case RotationSpeed.HIGH: return 100;
+            default: return 0;
         }
     }
 
-    private getHeaterCoolerTargetState(mode: Mode): CharacteristicValue {
-        if(mode === Mode.AUTO) {
+    private isClimateMode(mode: Mode): boolean {
+        return mode === Mode.AUTO || mode === Mode.COOLING;
+    }
+
+    private isClimateActive(context: AirConditionerInterface): boolean {
+        return context.active && this.isClimateMode(context.mode);
+    }
+
+    private isBlowing(context: AirConditionerInterface): boolean {
+        return context.active && context.mode !== Mode.DEHUMIDIFYING;
+    }
+
+    private isWindAuto(context: AirConditionerInterface): boolean {
+        return context.mode === Mode.AUTO || context.rotationSpeed === RotationSpeed.AUTO;
+    }
+
+    /**
+     * The wallpad accepts integer temperatures within 18..30 only — every value coming
+     * from a threshold handle floors into that range.
+     */
+    private toWallPadTemperature(value: number): number {
+        return Math.min(MAX_TEMPERATURE, Math.max(MIN_TEMPERATURE, Math.floor(value)));
+    }
+
+    /**
+     * Wind slider percentage. While the wind is wallpad-managed the slider parks at
+     * full so it reads as "auto is in charge"; the manual speed stays preserved in
+     * `lastManualRotationSpeed` underneath.
+     */
+    private getDisplayRotationSpeed(context: AirConditionerInterface): number {
+        if(!this.isBlowing(context)) {
+            return 0;
+        }
+        if(this.isWindAuto(context)) {
+            return 100;
+        }
+        return this.rotationSpeedToHomebridge(context.lastManualRotationSpeed);
+    }
+
+    /**
+     * The cooling threshold is the one and only temperature control: the COOL dial and
+     * the top handle of the AUTO pair both show the target itself, keeping the two
+     * views in the same tone.
+     */
+    private getDisplayCoolingThreshold(context: AirConditionerInterface): number {
+        return this.getThresholdTemperature(context);
+    }
+
+    /**
+     * The heating threshold exists only so the Home app renders a temperature control
+     * in AUTO (it wants a heat/cool pair). It parks one degree BELOW the minimum
+     * target, so the cooling handle can travel the whole range in both directions —
+     * including down to the minimum itself; writes to it are dropped entirely
+     * (see the SET handler).
+     */
+    private getDisplayHeatingThreshold(): number {
+        return MIN_TEMPERATURE - 1;
+    }
+
+    getThresholdTemperature(context: AirConditionerInterface): number {
+        return Math.min(MAX_TEMPERATURE, Math.max(MIN_TEMPERATURE, context.desiredTemperature));
+    }
+
+    getCurrentTemperature(context: AirConditionerInterface): number {
+        return context.currentTemperature;
+    }
+
+    getCurrentState(context: AirConditionerInterface): CharacteristicValue {
+        if(!this.isClimateActive(context)) {
+            return this.api.hap.Characteristic.CurrentHeaterCoolerState.INACTIVE;
+        }
+        if(context.desiredTemperature < context.currentTemperature) {
+            return this.api.hap.Characteristic.CurrentHeaterCoolerState.COOLING;
+        }
+        return this.api.hap.Characteristic.CurrentHeaterCoolerState.IDLE;
+    }
+
+    private getHeaterCoolerTargetState(context: AirConditionerInterface): CharacteristicValue {
+        if(context.mode === Mode.AUTO) {
             return this.api.hap.Characteristic.TargetHeaterCoolerState.AUTO;
         }
         return this.api.hap.Characteristic.TargetHeaterCoolerState.COOL;
     }
 
-    private getCurrentDehumidifierState(accessory: PlatformAccessory): CharacteristicValue {
-        const context = this.getAccessoryInterface(accessory);
+    private getCurrentDehumidifierState(context: AirConditionerInterface): CharacteristicValue {
         if(context.active && context.mode === Mode.DEHUMIDIFYING) {
             return this.api.hap.Characteristic.CurrentHumidifierDehumidifierState.DEHUMIDIFYING;
         }
         return this.api.hap.Characteristic.CurrentHumidifierDehumidifierState.INACTIVE;
     }
 
-    private getCurrentAirPurifierState(accessory: PlatformAccessory): CharacteristicValue {
+    private gestureOf(context: AirConditionerInterface): TemperatureGesture {
+        let gesture = this.temperatureGestures[context.deviceId];
+        if(!gesture) {
+            gesture = {};
+            this.temperatureGestures[context.deviceId] = gesture;
+        }
+        return gesture;
+    }
+
+    /**
+     * Debounced state propagation. The pending cooling write of one gesture is applied
+     * here, and every locked/dropped write (parked heating handle, wind in auto, ...)
+     * gets its UI reverted by the trailing sync in one pass.
+     */
+    private scheduleSync(accessory: PlatformAccessory) {
         const context = this.getAccessoryInterface(accessory);
-        if(context.active && context.mode === Mode.FAN) {
-            return this.api.hap.Characteristic.CurrentAirPurifierState.PURIFYING_AIR;
+        const gesture = this.gestureOf(context);
+        if(gesture.timer) {
+            clearTimeout(gesture.timer);
         }
-        return this.api.hap.Characteristic.CurrentAirPurifierState.INACTIVE;
-    }
-
-    private isTemperatureAdjustable(context: AirConditionerInterface): boolean {
-        return context.active && (context.mode === Mode.AUTO || context.mode === Mode.COOLING);
-    }
-
-    private setAllInactive(accessory: PlatformAccessory) {
-        for(const serviceType of this.serviceTypes) {
-            if(serviceType.UUID === this.api.hap.Service.AccessoryInformation.UUID) {
-                continue;
+        gesture.timer = setTimeout(() => {
+            gesture.timer = undefined;
+            const pending = gesture.pendingCool;
+            gesture.pendingCool = undefined;
+            if(pending !== undefined) {
+                this.applyThresholdTemperature(accessory, this.toWallPadTemperature(pending));
             }
-            this.getService(accessory, serviceType)
-                .setCharacteristic(this.api.hap.Characteristic.Active, this.api.hap.Characteristic.Active.INACTIVE);
+            this.syncAccessoryState(accessory);
+            this.armCommandGuards(context);
+        }, GESTURE_WINDOW_MILLISECONDS);
+    }
+
+    /**
+     * Arm the command + temperature guards from the just-committed optimistic context,
+     * so incoming pushes (see applyWallPadState) can tell our own command's settling
+     * from stale pre-command state. Called only from the user-action path (scheduleSync),
+     * never when applying wallpad state, so incoming state never re-arms the guards.
+     */
+    private armCommandGuards(context: AirConditionerInterface) {
+        const gesture = this.gestureOf(context);
+        gesture.pendingPower = context.active;
+        gesture.pendingMode = context.mode;
+        gesture.pendingSince = Date.now();
+        if(this.isClimateActive(context)) {
+            gesture.tempGuardTarget = this.getThresholdTemperature(context) as number;
+            gesture.tempGuardUntil = Date.now() + TEMP_GUARD_MILLISECONDS;
+            // Not seeded to "now": the first contradicting push must re-assert immediately;
+            // a fast wallpad override would otherwise be swallowed by the throttle.
+            gesture.lastReassertAt = 0;
+        } else {
+            gesture.tempGuardUntil = undefined; // temp isn't a control off/dehumidifying
         }
+    }
+
+    /**
+     * WallPad state -> context, gated by the command + temperature guards. Mutates the
+     * existing context in place (unlike first-sight creation), so fields the op does not
+     * report — lastManualRotationSpeed, lastClimateMode — persist naturally.
+     */
+    private applyWallPadState(accessory: PlatformAccessory, op: any) {
+        const context = this.getAccessoryInterface(accessory);
+        this.normalizeContext(context); // in case a push lands before configureAccessory
+        const gesture = this.gestureOf(context);
+        const incPower = op["status"] === "on";
+        const incMode = (op["mode"] as Mode) || context.mode;
+
+        // Command guard: drop stale pushes that still carry the pre-command power/mode.
+        if(gesture.pendingSince !== undefined) {
+            const confirmed = incPower === gesture.pendingPower
+                && (!incPower || incMode === gesture.pendingMode);
+            if(confirmed) {
+                gesture.pendingSince = undefined; // wallpad caught up — live again
+            } else if(Date.now() - gesture.pendingSince < COMMAND_GUARD_MILLISECONDS) {
+                return; // pre-command state still in flight — ignore
+            } else {
+                gesture.pendingSince = undefined; // cap reached — adopt whatever comes
+            }
+        }
+
+        // Temperature re-assert guard: hold our target on screen and re-send it while the
+        // wallpad reports its own stored setpoint. Held for the whole window (never
+        // released on the first match) because the wallpad echoes our value once, then
+        // snaps back to its stored per-mode value.
+        let holdTemp = false;
+        const incTemp = Number(op["desired_temp"] ?? op["set_temp"]);
+        if(gesture.tempGuardUntil !== undefined && incPower && this.isClimateMode(incMode)) {
+            if(Date.now() >= gesture.tempGuardUntil) {
+                gesture.tempGuardUntil = undefined; // cap reached — adopt whatever comes
+            } else {
+                holdTemp = true;
+                if(!Number.isNaN(incTemp) && incTemp !== gesture.tempGuardTarget
+                    && Date.now() - (gesture.lastReassertAt ?? 0) > REASSERT_THROTTLE_MILLISECONDS) {
+                    gesture.lastReassertAt = Date.now();
+                    this.reassertThresholdTemperature(context, incMode, gesture.tempGuardTarget as number);
+                }
+            }
+        }
+
+        context.active = incPower;
+        context.mode = incMode;
+        if(op["current_temp"]) {
+            context.currentTemperature = Number(op["current_temp"]);
+        }
+        if(holdTemp) {
+            context.desiredTemperature = gesture.tempGuardTarget as number;
+        } else {
+            const target = op["desired_temp"] ?? op["set_temp"];
+            if(target) {
+                context.desiredTemperature = Number(target);
+            }
+        }
+        const windSpeed = op["wind_speed"] as RotationSpeed | undefined;
+        context.rotationSpeed = incPower ? (windSpeed || RotationSpeed.OFF) : RotationSpeed.OFF;
+        if(windSpeed === RotationSpeed.LOW || windSpeed === RotationSpeed.MIDDLE || windSpeed === RotationSpeed.HIGH) {
+            context.lastManualRotationSpeed = windSpeed;
+        }
+        if(this.isClimateMode(context.mode)) {
+            context.lastClimateMode = context.mode;
+        }
+        context.init = true;
+
+        this.syncAccessoryState(accessory);
+    }
+
+    /**
+     * Fire a standalone set_temp so the wallpad adopts our value even after it dropped
+     * the set_temp bundled with a mode change. Sent immediately (not deferred): the guard
+     * needs the correction to reach the wallpad within its window.
+     */
+    private reassertThresholdTemperature(context: AirConditionerInterface, mode: Mode, target: number) {
+        const device = this.findDevice(context.deviceId);
+        if(!device) {
+            return;
+        }
+        void this.setDeviceState({
+            ...device, op: {
+                control: "on",
+                mode: mode.toString(),
+                set_temp: target,
+            },
+        }).catch(() => { /* best-effort correction; the guard retries on the next push */ });
+    }
+
+    private applyThresholdTemperature(accessory: PlatformAccessory, target: number) {
+        const context = this.getAccessoryInterface(accessory);
+        if(context.desiredTemperature === target) {
+            return;
+        }
+        const device = this.findDevice(context.deviceId);
+        if(!device) {
+            this.log.warn("Unknown device: %s", context.deviceId);
+            return;
+        }
+        context.desiredTemperature = target;
+        this.defer(device.deviceId, this.setDeviceState({
+            ...device, op: {
+                "set_temp": target,
+            },
+        }));
+    }
+
+    /**
+     * WallPad state -> HomeKit. Always `updateCharacteristic`: SET handlers must never
+     * re-enter from state propagation, or commands would echo back to the wallpad.
+     */
+    private syncAccessoryState(accessory: PlatformAccessory) {
+        const context = this.getAccessoryInterface(accessory);
+        const climate = this.isClimateActive(context);
+        const blowing = this.isBlowing(context);
+        const dehumidifying = context.active && context.mode === Mode.DEHUMIDIFYING;
+
+        this.getService(accessory, this.api.hap.Service.HeaterCooler)
+            .updateCharacteristic(this.api.hap.Characteristic.Active, climate
+                ? this.api.hap.Characteristic.Active.ACTIVE
+                : this.api.hap.Characteristic.Active.INACTIVE)
+            .updateCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState, this.getCurrentState(context))
+            .updateCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState, this.getHeaterCoolerTargetState(context))
+            .updateCharacteristic(this.api.hap.Characteristic.CoolingThresholdTemperature, this.getDisplayCoolingThreshold(context))
+            .updateCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature, this.getDisplayHeatingThreshold())
+            .updateCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.getCurrentTemperature(context))
+            .updateCharacteristic(this.api.hap.Characteristic.RotationSpeed, this.getDisplayRotationSpeed(context));
+
+        this.getService(accessory, this.api.hap.Service.Fanv2)
+            .updateCharacteristic(this.api.hap.Characteristic.Active, blowing
+                ? this.api.hap.Characteristic.Active.ACTIVE
+                : this.api.hap.Characteristic.Active.INACTIVE)
+            .updateCharacteristic(this.api.hap.Characteristic.TargetFanState, this.isWindAuto(context)
+                ? this.api.hap.Characteristic.TargetFanState.AUTO
+                : this.api.hap.Characteristic.TargetFanState.MANUAL)
+            .updateCharacteristic(this.api.hap.Characteristic.CurrentFanState, blowing
+                ? this.api.hap.Characteristic.CurrentFanState.BLOWING_AIR
+                : this.api.hap.Characteristic.CurrentFanState.INACTIVE)
+            .updateCharacteristic(this.api.hap.Characteristic.RotationSpeed, this.getDisplayRotationSpeed(context));
+
+        this.getService(accessory, this.api.hap.Service.HumidifierDehumidifier)
+            .updateCharacteristic(this.api.hap.Characteristic.Active, dehumidifying
+                ? this.api.hap.Characteristic.Active.ACTIVE
+                : this.api.hap.Characteristic.Active.INACTIVE)
+            .updateCharacteristic(this.api.hap.Characteristic.CurrentHumidifierDehumidifierState, this.getCurrentDehumidifierState(context))
+            .updateCharacteristic(this.api.hap.Characteristic.CurrentRelativeHumidity, getGlobalIndoorRelativeHumidity());
+
+        const gesture = this.gestureOf(context);
+        gesture.coolMirror = this.getDisplayCoolingThreshold(context);
     }
 
     private async activateMode(accessory: PlatformAccessory, mode: Mode): Promise<boolean> {
@@ -109,11 +433,17 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
             control: "on",
             mode: mode.toString(),
         };
-        if(mode === Mode.AUTO || mode === Mode.COOLING) {
-            op["set_temp"] = this.getThresholdTemperature(accessory);
+        if(this.isClimateMode(mode)) {
+            op["set_temp"] = this.getThresholdTemperature(context);
         }
-        if((mode === Mode.COOLING || mode === Mode.FAN) && context.rotationSpeed !== RotationSpeed.OFF) {
-            op["wind_speed"] = context.rotationSpeed.toString();
+        if(mode === Mode.COOLING) {
+            // Re-entering cooling restores the previous wind, incl. wallpad-managed "auto".
+            op["wind_speed"] = (context.rotationSpeed === RotationSpeed.OFF
+                ? context.lastManualRotationSpeed
+                : context.rotationSpeed).toString();
+        } else if(mode === Mode.FAN) {
+            // Fan mode forbids "auto" wind.
+            op["wind_speed"] = context.lastManualRotationSpeed.toString();
         }
         const success = await this.setDeviceState({
             ...device,
@@ -124,6 +454,14 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         }
         context.active = true;
         context.mode = mode;
+        if(this.isClimateMode(mode)) {
+            context.lastClimateMode = mode;
+        }
+        if(mode === Mode.COOLING && context.rotationSpeed === RotationSpeed.OFF) {
+            context.rotationSpeed = context.lastManualRotationSpeed;
+        } else if(mode === Mode.FAN) {
+            context.rotationSpeed = context.lastManualRotationSpeed;
+        }
         return true;
     }
 
@@ -146,63 +484,19 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         return true;
     }
 
-    private async onSetServiceActive(
-        accessory: PlatformAccessory,
-        serviceType: ServiceType,
-        active: boolean,
-        mode: Mode,
-        callback: CharacteristicSetCallback,
-    ) {
-        const context = this.getAccessoryInterface(accessory);
-        const targetServiceActive = context.active && context.mode === mode;
-        if(targetServiceActive === active) {
-            callback(undefined);
-            return;
-        }
-        let success;
-        if(active) {
-            success = await this.activateMode(accessory, mode);
-            if(success) {
-                this.setActive(accessory, serviceType);
-            }
-        } else {
-            success = await this.deactivate(accessory);
-            if(success) {
-                this.setAllInactive(accessory);
-            }
-        }
-        if(!success) {
-            callback(new Error("Failed to set the device state."));
-            return;
-        }
-        this.syncAccessoryState(accessory);
-        callback(undefined);
-    }
-
+    /**
+     * Shared handler for both wind sliders (HeaterCooler and Fanv2 both expose
+     * RotationSpeed so the wind stays adjustable in combined AND separated tile views).
+     */
     private async onSetRotationSpeed(
         accessory: PlatformAccessory,
         value: CharacteristicValue,
-        mode: Mode,
         callback: CharacteristicSetCallback,
     ) {
         const context = this.getAccessoryInterface(accessory);
         const numeric = value as number;
-        const newSpeed = this.homebridgeToRotationSpeed(numeric);
-        const oldSpeed = context.rotationSpeed;
-        if(oldSpeed === newSpeed) {
-            callback(undefined);
-            return;
-        }
-
-        const device = this.findDevice(context.deviceId);
-        if(!device) {
-            callback(new Error(`Unknown device: ${context.deviceId}`));
-            return;
-        }
-
-        if(newSpeed === RotationSpeed.OFF) {
+        if(numeric <= 0) {
             if(!context.active) {
-                context.rotationSpeed = RotationSpeed.OFF;
                 callback(undefined);
                 return;
             }
@@ -211,109 +505,115 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                 callback(new Error("Failed to set the device state."));
                 return;
             }
-            context.rotationSpeed = RotationSpeed.OFF;
-            this.setAllInactive(accessory);
-            this.syncAccessoryState(accessory);
+            this.scheduleSync(accessory);
             callback(undefined);
             return;
         }
-
-        const op: Record<string, any> = {
-            wind_speed: newSpeed.toString(),
-        };
-        if(!context.active || context.mode !== mode) {
-            op["control"] = "on";
-            op["mode"] = mode.toString();
-            context.mode = mode;
-            context.active = true;
-        }
-        const success = await this.setDeviceState({
-            ...device,
-            op,
-        });
-        if(!success) {
-            callback(new Error("Failed to set the device state."));
+        const wind = this.homebridgeToRotationSpeed(numeric);
+        if(!context.active) {
+            // The Home app often writes the slider just before Active=1 — remember the
+            // speed so the power-on that follows uses it, and revert the slider for now.
+            context.lastManualRotationSpeed = wind;
+            this.scheduleSync(accessory);
+            callback(undefined);
             return;
         }
-        context.rotationSpeed = newSpeed;
-        if(context.active) {
-            switch (context.mode) {
-                case Mode.AUTO:
-                case Mode.COOLING:
-                    this.setActive(accessory, this.api.hap.Service.HeaterCooler);
-                    break;
-                case Mode.DEHUMIDIFYING:
-                    this.setActive(accessory, this.api.hap.Service.HumidifierDehumidifier);
-                    break;
-                case Mode.FAN:
-                    this.setActive(accessory, this.api.hap.Service.AirPurifier);
-                    break;
+        if(context.mode === Mode.DEHUMIDIFYING) {
+            // Wind isn't a dehumidifying control. Touching it means "I want airflow" —
+            // leave dehumidifying and start fan mode at that speed instead of doing nothing.
+            context.lastManualRotationSpeed = wind;
+            const success = await this.activateMode(accessory, Mode.FAN);
+            if(!success) {
+                callback(new Error("Failed to set the device state."));
+                return;
             }
+            this.scheduleSync(accessory);
+            callback(undefined);
+            return;
         }
-        this.syncAccessoryState(accessory);
+        if(context.mode !== Mode.COOLING && context.mode !== Mode.FAN) {
+            // auto: the wallpad forbids wind control — revert.
+            this.scheduleSync(accessory);
+            callback(undefined);
+            return;
+        }
+        if(context.rotationSpeed === wind) {
+            callback(undefined);
+            return;
+        }
+        const device = this.findDevice(context.deviceId);
+        if(!device) {
+            callback(new Error(`Unknown device: ${context.deviceId}`));
+            return;
+        }
+        context.rotationSpeed = wind;
+        context.lastManualRotationSpeed = wind;
+        this.defer(device.deviceId, this.setDeviceState({
+            ...device, op: {
+                "wind_speed": wind.toString(),
+            },
+        }));
+        this.scheduleSync(accessory);
         callback(undefined);
     }
 
-    private syncAccessoryState(accessory: PlatformAccessory) {
-        const context = this.getAccessoryInterface(accessory);
-
-        const heaterCooler = this.getService(accessory, this.api.hap.Service.HeaterCooler);
-        const heaterCoolerMode = context.mode === Mode.AUTO || context.mode === Mode.COOLING;
-        const heaterActive = context.active && heaterCoolerMode;
-        heaterCooler
-            .setCharacteristic(this.api.hap.Characteristic.Active, heaterActive
-                ? this.api.hap.Characteristic.Active.ACTIVE
-                : this.api.hap.Characteristic.Active.INACTIVE)
-            .setCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState, this.getCurrentState(accessory))
-            .setCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState, this.getHeaterCoolerTargetState(context.mode))
-            .setCharacteristic(this.api.hap.Characteristic.CoolingThresholdTemperature, this.getThresholdTemperature(accessory))
-            .setCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.getCurrentTemperature(accessory))
-            .setCharacteristic(this.api.hap.Characteristic.RotationSpeed, this.rotationSpeedToHomebridge(context.rotationSpeed));
-
-        const dehumidifier = this.getService(accessory, this.api.hap.Service.HumidifierDehumidifier);
-        const dehumidifierActive = context.active && context.mode === Mode.DEHUMIDIFYING;
-        dehumidifier
-            .setCharacteristic(this.api.hap.Characteristic.Active, dehumidifierActive
-                ? this.api.hap.Characteristic.Active.ACTIVE
-                : this.api.hap.Characteristic.Active.INACTIVE)
-            .setCharacteristic(this.api.hap.Characteristic.CurrentHumidifierDehumidifierState, this.getCurrentDehumidifierState(accessory))
-            .setCharacteristic(this.api.hap.Characteristic.CurrentRelativeHumidity, getGlobalIndoorRelativeHumidity())
-            .setCharacteristic(this.api.hap.Characteristic.TargetHumidifierDehumidifierState,
-                this.api.hap.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER);
-
-        const airPurifier = this.getService(accessory, this.api.hap.Service.AirPurifier);
-        const fanActive = context.active && context.mode === Mode.FAN;
-        airPurifier
-            .setCharacteristic(this.api.hap.Characteristic.Active, fanActive
-                ? this.api.hap.Characteristic.Active.ACTIVE
-                : this.api.hap.Characteristic.Active.INACTIVE)
-            .setCharacteristic(this.api.hap.Characteristic.CurrentAirPurifierState, this.getCurrentAirPurifierState(accessory))
-            .setCharacteristic(this.api.hap.Characteristic.TargetAirPurifierState,
-                this.api.hap.Characteristic.TargetAirPurifierState.MANUAL)
-            .setCharacteristic(this.api.hap.Characteristic.RotationSpeed, this.rotationSpeedToHomebridge(context.rotationSpeed));
+    /**
+     * Migrate a context restored from an older cache: `lastManualRotationSpeed` and
+     * `lastClimateMode` did not exist before this rework, so a cached accessory carries
+     * them as undefined. Seed sane defaults before any handler can read them — otherwise
+     * powering on would command `mode: "undefined"` or throw on `undefined.toString()`.
+     */
+    private normalizeContext(context: AirConditionerInterface) {
+        if(context.lastManualRotationSpeed === undefined) {
+            const wind = context.rotationSpeed;
+            context.lastManualRotationSpeed = (wind === RotationSpeed.LOW
+                || wind === RotationSpeed.MIDDLE
+                || wind === RotationSpeed.HIGH) ? wind : RotationSpeed.LOW;
+        }
+        if(context.lastClimateMode === undefined) {
+            context.lastClimateMode = this.isClimateMode(context.mode) ? context.mode : Mode.COOLING;
+        }
     }
 
     configureAccessory(accessory: PlatformAccessory) {
         super.configureAccessory(accessory);
+        this.normalizeContext(this.getAccessoryInterface(accessory));
 
-        this.getService(accessory, this.api.hap.Service.HeaterCooler)
-            .getCharacteristic(this.api.hap.Characteristic.Active)
+        const heaterCooler = this.getService(accessory, this.api.hap.Service.HeaterCooler);
+        heaterCooler.setPrimaryService(true);
+
+        heaterCooler.getCharacteristic(this.api.hap.Characteristic.Active)
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                const active = value === this.api.hap.Characteristic.Active.ACTIVE;
                 const context = this.getAccessoryInterface(accessory);
-                const mode = context.mode === Mode.AUTO ? Mode.AUTO : Mode.COOLING;
-                await this.onSetServiceActive(accessory, this.api.hap.Service.HeaterCooler, active, mode, callback);
+                const active = value === this.api.hap.Characteristic.Active.ACTIVE;
+                if(this.isClimateActive(context) === active) {
+                    callback(undefined);
+                    return;
+                }
+                if(active) {
+                    const success = await this.activateMode(accessory, context.lastClimateMode);
+                    if(!success) {
+                        callback(new Error("Failed to set the device state."));
+                        return;
+                    }
+                } else if(this.isClimateMode(context.mode)) {
+                    const success = await this.deactivate(accessory);
+                    if(!success) {
+                        callback(new Error("Failed to set the device state."));
+                        return;
+                    }
+                }
+                this.scheduleSync(accessory);
+                callback(undefined);
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                const active = context.active && (context.mode === Mode.AUTO || context.mode === Mode.COOLING);
-                callback(undefined, active
+                callback(undefined, this.isClimateActive(context)
                     ? this.api.hap.Characteristic.Active.ACTIVE
                     : this.api.hap.Characteristic.Active.INACTIVE);
             });
 
-        this.getService(accessory, this.api.hap.Service.HeaterCooler)
-            .getCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState)
+        heaterCooler.getCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState)
             .setProps({
                 validValues: [
                     this.api.hap.Characteristic.CurrentHeaterCoolerState.INACTIVE,
@@ -322,11 +622,10 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                 ],
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.getCurrentState(accessory));
+                callback(undefined, this.getCurrentState(this.getAccessoryInterface(accessory)));
             });
 
-        this.getService(accessory, this.api.hap.Service.HeaterCooler)
-            .getCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState)
+        heaterCooler.getCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState)
             .setProps({
                 validValues: [
                     this.api.hap.Characteristic.TargetHeaterCoolerState.AUTO,
@@ -334,17 +633,18 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                 ],
             })
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                const context = this.getAccessoryInterface(accessory);
                 const targetMode = value === this.api.hap.Characteristic.TargetHeaterCoolerState.AUTO
                     ? Mode.AUTO
                     : Mode.COOLING;
-                const context = this.getAccessoryInterface(accessory);
                 if(context.mode === targetMode) {
                     callback(undefined);
                     return;
                 }
-                context.mode = targetMode;
+                context.lastClimateMode = targetMode;
                 if(!context.active) {
-                    this.syncAccessoryState(accessory);
+                    context.mode = targetMode;
+                    this.scheduleSync(accessory);
                     callback(undefined);
                     return;
                 }
@@ -353,57 +653,73 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                     callback(new Error("Failed to set the device state."));
                     return;
                 }
-                this.setActive(accessory, this.api.hap.Service.HeaterCooler);
-                this.syncAccessoryState(accessory);
+                this.scheduleSync(accessory);
                 callback(undefined);
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                const context = this.getAccessoryInterface(accessory);
-                callback(undefined, this.getHeaterCoolerTargetState(context.mode));
+                callback(undefined, this.getHeaterCoolerTargetState(this.getAccessoryInterface(accessory)));
             });
 
-        this.getService(accessory, this.api.hap.Service.HeaterCooler)
-            .getCharacteristic(this.api.hap.Characteristic.CoolingThresholdTemperature)
-            .setValue(this.getThresholdTemperature(accessory))
+        heaterCooler.getCharacteristic(this.api.hap.Characteristic.CoolingThresholdTemperature)
             .setProps({
-                minValue: MIN_TEMPERATURE,
+                // Matches the parked heating handle (min - 1): the Home app renders the
+                // AUTO pair on one shared track bounded by this range, and a floor of 18
+                // would clamp the parked handle up to 18 on every gesture. Targets still
+                // clamp into 18..30 on write.
+                minValue: MIN_TEMPERATURE - 1,
                 maxValue: MAX_TEMPERATURE,
                 minStep: 1,
             })
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                if(context.desiredTemperature === value || !this.isTemperatureAdjustable(context)) {
-                    callback(undefined);
-                    return;
+                const gesture = this.gestureOf(context);
+                if(value !== gesture.coolMirror
+                    && context.active && this.isClimateMode(context.mode)) {
+                    gesture.pendingCool = value as number;
                 }
-                const device = this.findDevice(context.deviceId);
-                if(!device) {
-                    callback(new Error(`Unknown device: ${context.deviceId}`));
-                    return;
-                }
-                context.desiredTemperature = value as number;
-                this.defer(device.deviceId, this.setDeviceState({
-                    ...device, op: {
-                        "set_temp": this.getThresholdTemperature(accessory),
-                    },
-                }));
+                this.scheduleSync(accessory);
                 callback(undefined);
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.getThresholdTemperature(accessory));
+                callback(undefined, this.getDisplayCoolingThreshold(this.getAccessoryInterface(accessory)));
             });
 
-        // CurrentTemperature
-        this.getService(accessory, this.api.hap.Service.HeaterCooler)
-            .getCharacteristic(this.api.hap.Characteristic.CurrentTemperature)
-            .setValue(this.getCurrentTemperature(accessory))
+        heaterCooler.getCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature)
+            .setProps({
+                minValue: MIN_TEMPERATURE - 1,
+                maxValue: MAX_TEMPERATURE,
+                minStep: 1,
+            })
+            .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                // The heating handle is parked and is not a control: every write —
+                // user drags and the Home app's own "heat = cool - 1" rewrites alike —
+                // is dropped, and the trailing sync snaps it back. The late forced
+                // notification covers the app ignoring that immediate correction.
+                if(value !== this.getDisplayHeatingThreshold()) {
+                    const gesture = this.gestureOf(this.getAccessoryInterface(accessory));
+                    if(gesture.parkTimer) {
+                        clearTimeout(gesture.parkTimer);
+                    }
+                    gesture.parkTimer = setTimeout(() => {
+                        gesture.parkTimer = undefined;
+                        this.getService(accessory, this.api.hap.Service.HeaterCooler)
+                            .getCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature)
+                            .sendEventNotification(this.getDisplayHeatingThreshold());
+                    }, LATE_PARK_PUSH_MILLISECONDS);
+                }
+                this.scheduleSync(accessory);
+                callback(undefined);
+            })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.getCurrentTemperature(accessory));
+                callback(undefined, this.getDisplayHeatingThreshold());
             });
 
-        // RotationSpeed
-        this.getService(accessory, this.api.hap.Service.HeaterCooler)
-            .getCharacteristic(this.api.hap.Characteristic.RotationSpeed)
+        heaterCooler.getCharacteristic(this.api.hap.Characteristic.CurrentTemperature)
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, this.getCurrentTemperature(this.getAccessoryInterface(accessory)));
+            });
+
+        heaterCooler.getCharacteristic(this.api.hap.Characteristic.RotationSpeed)
             .setProps({
                 format: this.api.hap.Formats.FLOAT,
                 minValue: 0,
@@ -411,43 +727,142 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                 minStep: ROTATION_SPEED_STEP,
             })
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                await this.onSetRotationSpeed(accessory, value, Mode.COOLING, callback);
+                await this.onSetRotationSpeed(accessory, value, callback);
+            })
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, this.getDisplayRotationSpeed(this.getAccessoryInterface(accessory)));
+            });
+
+        this.configureFan(accessory);
+        this.configureDehumidifier(accessory);
+    }
+
+    private configureFan(accessory: PlatformAccessory): Service {
+        const fan = this.getService(accessory, this.api.hap.Service.Fanv2);
+        fan.getCharacteristic(this.api.hap.Characteristic.Active)
+            .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                const context = this.getAccessoryInterface(accessory);
+                if(value === this.api.hap.Characteristic.Active.ACTIVE) {
+                    if(!context.active || context.mode === Mode.DEHUMIDIFYING) {
+                        const success = await this.activateMode(accessory, Mode.FAN);
+                        if(!success) {
+                            callback(new Error("Failed to set the device state."));
+                            return;
+                        }
+                    }
+                    // cool/auto: already blowing — nothing to do.
+                } else {
+                    if(context.active && context.mode === Mode.FAN) {
+                        const success = await this.deactivate(accessory);
+                        if(!success) {
+                            callback(new Error("Failed to set the device state."));
+                            return;
+                        }
+                    }
+                    // cool/auto: cannot stop only the fan — revert via sync.
+                }
+                this.scheduleSync(accessory);
+                callback(undefined);
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                callback(undefined, this.rotationSpeedToHomebridge(context.rotationSpeed));
+                callback(undefined, this.isBlowing(context)
+                    ? this.api.hap.Characteristic.Active.ACTIVE
+                    : this.api.hap.Characteristic.Active.INACTIVE);
             });
 
-        this.configureDehumidifier(accessory);
-        this.configureAirPurifier(accessory);
+        fan.getCharacteristic(this.api.hap.Characteristic.TargetFanState)
+            .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                const context = this.getAccessoryInterface(accessory);
+                const device = this.findDevice(context.deviceId);
+                if(!device) {
+                    callback(new Error(`Unknown device: ${context.deviceId}`));
+                    return;
+                }
+                if(value === this.api.hap.Characteristic.TargetFanState.AUTO) {
+                    // Wallpad-managed wind is a cooling-only feature; auto mode is
+                    // already wallpad-managed and fan mode forbids it — revert those.
+                    if(context.active && context.mode === Mode.COOLING
+                        && context.rotationSpeed !== RotationSpeed.AUTO) {
+                        context.rotationSpeed = RotationSpeed.AUTO;
+                        this.defer(device.deviceId, this.setDeviceState({
+                            ...device, op: {
+                                "wind_speed": RotationSpeed.AUTO.toString(),
+                            },
+                        }));
+                    }
+                } else {
+                    if(context.active && context.mode === Mode.COOLING
+                        && context.rotationSpeed === RotationSpeed.AUTO) {
+                        context.rotationSpeed = context.lastManualRotationSpeed;
+                        this.defer(device.deviceId, this.setDeviceState({
+                            ...device, op: {
+                                "wind_speed": context.lastManualRotationSpeed.toString(),
+                            },
+                        }));
+                    }
+                    // auto mode: wind is wallpad-managed — MANUAL requests revert via sync.
+                }
+                this.scheduleSync(accessory);
+                callback(undefined);
+            })
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                const context = this.getAccessoryInterface(accessory);
+                callback(undefined, this.isWindAuto(context)
+                    ? this.api.hap.Characteristic.TargetFanState.AUTO
+                    : this.api.hap.Characteristic.TargetFanState.MANUAL);
+            });
+
+        fan.getCharacteristic(this.api.hap.Characteristic.CurrentFanState)
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                const context = this.getAccessoryInterface(accessory);
+                callback(undefined, this.isBlowing(context)
+                    ? this.api.hap.Characteristic.CurrentFanState.BLOWING_AIR
+                    : this.api.hap.Characteristic.CurrentFanState.INACTIVE);
+            });
+
+        fan.getCharacteristic(this.api.hap.Characteristic.RotationSpeed)
+            .setProps({
+                format: this.api.hap.Formats.FLOAT,
+                minValue: 0,
+                maxValue: 100,
+                minStep: ROTATION_SPEED_STEP,
+            })
+            .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                await this.onSetRotationSpeed(accessory, value, callback);
+            })
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                callback(undefined, this.getDisplayRotationSpeed(this.getAccessoryInterface(accessory)));
+            });
+        return fan;
     }
 
-    getThresholdTemperature(accessory: PlatformAccessory): CharacteristicValue {
-        const context = this.getAccessoryInterface(accessory);
-        return Math.max(MIN_TEMPERATURE, Math.min(MAX_TEMPERATURE, context.desiredTemperature));
-    }
-
-    getCurrentTemperature(accessory: PlatformAccessory): CharacteristicValue {
-        const context = this.getAccessoryInterface(accessory);
-        return context.currentTemperature;
-    }
-
-    getCurrentState(accessory: PlatformAccessory) {
-        const context = this.getAccessoryInterface(accessory);
-        if(!context.active || (context.mode !== Mode.COOLING && context.mode !== Mode.AUTO)) {
-            return this.api.hap.Characteristic.CurrentHeaterCoolerState.INACTIVE;
-        }
-        if(context.active && context.desiredTemperature < context.currentTemperature)
-            return this.api.hap.Characteristic.CurrentHeaterCoolerState.COOLING;
-        return this.api.hap.Characteristic.CurrentHeaterCoolerState.IDLE;
-    }
-
-    configureDehumidifier(accessory: PlatformAccessory): Service {
+    private configureDehumidifier(accessory: PlatformAccessory): Service {
         const service = this.getService(accessory, this.api.hap.Service.HumidifierDehumidifier);
         service.getCharacteristic(this.api.hap.Characteristic.Active)
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
+                const context = this.getAccessoryInterface(accessory);
                 const active = value === this.api.hap.Characteristic.Active.ACTIVE;
-                await this.onSetServiceActive(accessory, this.api.hap.Service.HumidifierDehumidifier, active, Mode.DEHUMIDIFYING, callback);
+                const dehumidifying = context.active && context.mode === Mode.DEHUMIDIFYING;
+                if(dehumidifying === active) {
+                    callback(undefined);
+                    return;
+                }
+                if(active) {
+                    const success = await this.activateMode(accessory, Mode.DEHUMIDIFYING);
+                    if(!success) {
+                        callback(new Error("Failed to set the device state."));
+                        return;
+                    }
+                } else {
+                    const success = await this.deactivate(accessory);
+                    if(!success) {
+                        callback(new Error("Failed to set the device state."));
+                        return;
+                    }
+                }
+                this.scheduleSync(accessory);
+                callback(undefined);
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
@@ -464,15 +879,15 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                 ],
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.getCurrentDehumidifierState(accessory));
+                callback(undefined, this.getCurrentDehumidifierState(this.getAccessoryInterface(accessory)));
             });
         service.getCharacteristic(this.api.hap.Characteristic.TargetHumidifierDehumidifierState)
-            .setValue(this.api.hap.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER)
             .setProps({
                 validValues: [
                     this.api.hap.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER,
                 ],
             })
+            .updateValue(this.api.hap.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER)
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 callback(undefined, this.api.hap.Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER);
             });
@@ -483,75 +898,31 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         return service;
     }
 
-    configureAirPurifier(accessory: PlatformAccessory): Service {
-        const service = this.getService(accessory, this.api.hap.Service.AirPurifier);
-        service.getCharacteristic(this.api.hap.Characteristic.Active)
-            .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                const active = value === this.api.hap.Characteristic.Active.ACTIVE;
-                await this.onSetServiceActive(accessory, this.api.hap.Service.AirPurifier, active, Mode.FAN, callback);
-            })
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                const context = this.getAccessoryInterface(accessory);
-                const active = context.active && context.mode === Mode.FAN;
-                callback(undefined, active
-                    ? this.api.hap.Characteristic.Active.ACTIVE
-                    : this.api.hap.Characteristic.Active.INACTIVE);
-            });
-        service.getCharacteristic(this.api.hap.Characteristic.CurrentAirPurifierState)
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.getCurrentAirPurifierState(accessory));
-            });
-        service.getCharacteristic(this.api.hap.Characteristic.TargetAirPurifierState)
-            .setProps({
-                validValues: [this.api.hap.Characteristic.TargetAirPurifierState.MANUAL],
-            })
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                callback(undefined, this.api.hap.Characteristic.TargetAirPurifierState.MANUAL);
-            });
-        service.getCharacteristic(this.api.hap.Characteristic.RotationSpeed)
-            .setProps({
-                format: this.api.hap.Formats.FLOAT,
-                minValue: 0,
-                maxValue: 100,
-                minStep: ROTATION_SPEED_STEP,
-            })
-            .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                await this.onSetRotationSpeed(accessory, value, Mode.FAN, callback);
-            })
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                const context = this.getAccessoryInterface(accessory);
-                callback(undefined, this.rotationSpeedToHomebridge(context.rotationSpeed));
-            });
-        return service;
-    }
-
-    setActive(accessory: PlatformAccessory, serviceType: ServiceType) {
-        // Activate the service only.
-        for(const service of this.serviceTypes) {
-            if(service.UUID === this.api.hap.Service.AccessoryInformation.UUID) {
-                continue;
-            }
-            if(service.UUID === serviceType.UUID) {
-                this.getService(accessory, service)
-                    .setCharacteristic(this.api.hap.Characteristic.Active, this.api.hap.Characteristic.Active.ACTIVE);
-            } else {
-                this.getService(accessory, service)
-                    .setCharacteristic(this.api.hap.Characteristic.Active, this.api.hap.Characteristic.Active.INACTIVE);
-            }
-        }
-    }
-
     register() {
         super.register();
 
         this.addDeviceListener((devices) => {
             for(const device of devices) {
+                // Existing accessory: route the push through the command/temperature
+                // guards, mutating context in place (see applyWallPadState).
+                const existing = this.findAccessory(device.deviceId);
+                if(existing) {
+                    this.applyWallPadState(existing, device.op);
+                    continue;
+                }
+
+                // First sight: build the full initial context and create the accessory.
                 const active = device.op["status"] === "on";
-                const currentTemperature = device.op["current_temp"] ? Number(device.op["current_temp"]) : MIN_TEMPERATURE || MIN_TEMPERATURE;
+                const currentTemperature = device.op["current_temp"] ? Number(device.op["current_temp"]) : MIN_TEMPERATURE;
                 const targetTemperature = device.op["desired_temp"] ?? device.op["set_temp"];
-                const desiredTemperature = targetTemperature ? Number(targetTemperature) : MIN_TEMPERATURE || MIN_TEMPERATURE;
-                const rotationSpeed = active ? device.op["wind_speed"] as RotationSpeed || RotationSpeed.OFF : RotationSpeed.OFF;
+                const desiredTemperature = targetTemperature ? Number(targetTemperature) : MIN_TEMPERATURE;
+                const windSpeed = device.op["wind_speed"] as RotationSpeed | undefined;
+                const rotationSpeed = active ? (windSpeed || RotationSpeed.OFF) : RotationSpeed.OFF;
                 const operationMode = device.op["mode"] as Mode || Mode.AUTO;
+                const isManualWind = windSpeed === RotationSpeed.LOW
+                    || windSpeed === RotationSpeed.MIDDLE
+                    || windSpeed === RotationSpeed.HIGH;
+
                 const accessory = this.addOrGetAccessory({
                     deviceId: device.deviceId,
                     deviceType: device.deviceType,
@@ -561,6 +932,8 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                     currentTemperature,
                     desiredTemperature,
                     rotationSpeed,
+                    lastManualRotationSpeed: isManualWind ? windSpeed : RotationSpeed.LOW,
+                    lastClimateMode: this.isClimateMode(operationMode) ? operationMode : Mode.COOLING,
                     mode: operationMode,
                 });
                 if(!accessory) continue;

--- a/homebridge/accessories/smart-elife/air-conditioner.ts
+++ b/homebridge/accessories/smart-elife/air-conditioner.ts
@@ -903,11 +903,16 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
 
         this.addDeviceListener((devices) => {
             for(const device of devices) {
-                // Existing accessory: route the push through the command/temperature
-                // guards, mutating context in place (see applyWallPadState).
+                // Existing accessory: still run it through addOrGetAccessory,
+                // so the "disabled in config -> unregister" path there keeps owning removal.
+                // Feed it the current context (not the push),
+                // so a surviving accessory is re-assigned to itself unchanged,
+                // then let applyWallPadState apply the push in place through the command/temperature guards.
                 const existing = this.findAccessory(device.deviceId);
                 if(existing) {
-                    this.applyWallPadState(existing, device.op);
+                    const kept = this.addOrGetAccessory(this.getAccessoryInterface(existing));
+                    if(!kept) continue; // disabled -> unregistered
+                    this.applyWallPadState(kept, device.op);
                     continue;
                 }
 

--- a/homebridge/accessories/smart-elife/air-conditioner.ts
+++ b/homebridge/accessories/smart-elife/air-conditioner.ts
@@ -298,13 +298,13 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         const context = this.getAccessoryInterface(accessory);
         this.normalizeContext(context); // in case a push lands before configureAccessory
         const gesture = this.gestureOf(context);
-        const incPower = op["status"] === "on";
-        const incMode = (op["mode"] as Mode) || context.mode;
+        const reportedPower = op["status"] === "on";
+        const reportedMode = (op["mode"] as Mode) || context.mode;
 
         // Command guard: drop stale pushes that still carry the pre-command power/mode.
         if(gesture.pendingSince !== undefined) {
-            const confirmed = incPower === gesture.pendingPower
-                && (!incPower || incMode === gesture.pendingMode);
+            const confirmed = reportedPower === gesture.pendingPower
+                && (!reportedPower || reportedMode === gesture.pendingMode);
             if(confirmed) {
                 gesture.pendingSince = undefined; // wallpad caught up — live again
             } else if(Date.now() - gesture.pendingSince < COMMAND_GUARD_MILLISECONDS) {
@@ -319,22 +319,22 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         // Held for the whole window (never released on the first match)
         // because the wallpad echoes our value once, then snaps back to its stored per-mode value.
         let holdTemp = false;
-        const incTemp = Number(op["desired_temp"] ?? op["set_temp"]);
-        if(gesture.tempGuardUntil !== undefined && incPower && this.isClimateMode(incMode)) {
+        const reportedTemp = Number(op["desired_temp"] ?? op["set_temp"]);
+        if(gesture.tempGuardUntil !== undefined && reportedPower && this.isClimateMode(reportedMode)) {
             if(Date.now() >= gesture.tempGuardUntil) {
                 gesture.tempGuardUntil = undefined; // cap reached — adopt whatever comes
             } else {
                 holdTemp = true;
-                if(!Number.isNaN(incTemp) && incTemp !== gesture.tempGuardTarget
+                if(!Number.isNaN(reportedTemp) && reportedTemp !== gesture.tempGuardTarget
                     && Date.now() - (gesture.lastReassertAt ?? 0) > REASSERT_THROTTLE_MILLISECONDS) {
                     gesture.lastReassertAt = Date.now();
-                    this.reassertThresholdTemperature(context, incMode, gesture.tempGuardTarget as number);
+                    this.reassertThresholdTemperature(context, reportedMode, gesture.tempGuardTarget as number);
                 }
             }
         }
 
-        context.active = incPower;
-        context.mode = incMode;
+        context.active = reportedPower;
+        context.mode = reportedMode;
         if(op["current_temp"]) {
             context.currentTemperature = Number(op["current_temp"]);
         }
@@ -347,7 +347,7 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
             }
         }
         const windSpeed = op["wind_speed"] as RotationSpeed | undefined;
-        context.rotationSpeed = incPower ? (windSpeed || RotationSpeed.OFF) : RotationSpeed.OFF;
+        context.rotationSpeed = reportedPower ? (windSpeed || RotationSpeed.OFF) : RotationSpeed.OFF;
         if(windSpeed === RotationSpeed.LOW || windSpeed === RotationSpeed.MIDDLE || windSpeed === RotationSpeed.HIGH) {
             context.lastManualRotationSpeed = windSpeed;
         }

--- a/homebridge/accessories/smart-elife/air-conditioner.ts
+++ b/homebridge/accessories/smart-elife/air-conditioner.ts
@@ -16,8 +16,9 @@ interface AirConditionerInterface extends AccessoryInterface {
     rotationSpeed: RotationSpeed
 
     /**
-     * Last manual wind speed (LOW/MIDDLE/HIGH only). Preserved across auto/off so the
-     * slider can restore the previous manual speed when leaving wallpad-managed states.
+     * Last manual wind speed (LOW/MIDDLE/HIGH only).
+     * Preserved across auto/off so the slider can restore the previous manual speed
+     * when leaving wallpad-managed states.
      */
     lastManualRotationSpeed: RotationSpeed
 
@@ -50,12 +51,12 @@ const MIN_TEMPERATURE = 18;
 const MAX_TEMPERATURE = 30;
 
 /**
- * Per-device, never-persisted bookkeeping. Holds three unrelated concerns keyed off the
- * same device:
+ * Per-device, never-persisted bookkeeping.
+ * Holds three unrelated concerns keyed off the same device:
  *  - the temperature handle gesture (mirror + pending write, resolved in scheduleSync),
- *  - the command guard that suppresses stale pre-command state pushes, and
- *  - the temperature re-assert guard that forces our setpoint past the wallpad's own
- *    stored per-mode value.
+ *  - the command guard that suppresses stale pre-command state pushes,
+ *  - and the temperature re-assert guard that forces our setpoint
+ *    past the wallpad's own stored per-mode value.
  * See applyWallPadState and scheduleSync for how these interact with incoming pushes.
  */
 interface TemperatureGesture {
@@ -75,25 +76,24 @@ interface TemperatureGesture {
     lastReassertAt?: number
 }
 
-// Long enough that both writes of one Home app gesture (the moved handle plus the
-// app's rewrite of the untouched one) land in the same window, short enough that
-// the follower handle visibly snaps over right after the drag.
+// Long enough that both writes of one Home app gesture
+// (the moved handle plus the app's rewrite of the untouched one) land in the same window,
+// short enough that the follower handle visibly snaps over right after the drag.
 const GESTURE_WINDOW_MILLISECONDS = 120;
 
-// The Home app tends to ignore a correction that contradicts its own write for a few
-// seconds, and once our value is back at the park further syncs emit no event (no
-// change) — so the parked handle gets a late forced notification after this delay.
+// The Home app tends to ignore a correction that contradicts its own write for a few seconds,
+// and once our value is back at the park further syncs emit no event (no change) —
+// so the parked handle gets a late forced notification after this delay.
 const LATE_PARK_PUSH_MILLISECONDS = 2500;
 
-// After a command, ignore pushes that still carry the pre-command power/mode for up to
-// this long (or until the wallpad confirms our power+mode, whichever comes first). The
-// wallpad reflects a control op only after a few seconds and would otherwise fight the
-// optimistic UI.
+// After a command, ignore pushes that still carry the pre-command power/mode
+// for up to this long (or until the wallpad confirms our power+mode, whichever comes first).
+// The wallpad reflects a control op only after a few seconds and would otherwise fight the optimistic UI.
 const COMMAND_GUARD_MILLISECONDS = 7000;
 
-// The wallpad drops a set_temp bundled with a mode change and keeps its own stored
-// per-mode setpoint. Hold the displayed temperature at our target and re-send a
-// standalone set_temp until the wallpad reports it, capped at this window.
+// The wallpad drops a set_temp bundled with a mode change and keeps its own stored per-mode setpoint.
+// Hold the displayed temperature at our target and re-send a standalone set_temp until the wallpad
+// reports it, capped at this window.
 const TEMP_GUARD_MILLISECONDS = 10000;
 
 // Minimum spacing between standalone set_temp re-assert commands within the guard window.
@@ -144,17 +144,17 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
     }
 
     /**
-     * The wallpad accepts integer temperatures within 18..30 only — every value coming
-     * from a threshold handle floors into that range.
+     * The wallpad accepts integer temperatures within 18..30 only —
+     * every value coming from a threshold handle floors into that range.
      */
     private toWallPadTemperature(value: number): number {
         return Math.min(MAX_TEMPERATURE, Math.max(MIN_TEMPERATURE, Math.floor(value)));
     }
 
     /**
-     * Wind slider percentage. While the wind is wallpad-managed the slider parks at
-     * full so it reads as "auto is in charge"; the manual speed stays preserved in
-     * `lastManualRotationSpeed` underneath.
+     * Wind slider percentage.
+     * While the wind is wallpad-managed the slider parks at full so it reads as "auto is in charge";
+     * the manual speed stays preserved in `lastManualRotationSpeed` underneath.
      */
     private getDisplayRotationSpeed(context: AirConditionerInterface): number {
         if(!this.isBlowing(context)) {
@@ -167,20 +167,21 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
     }
 
     /**
-     * The cooling threshold is the one and only temperature control: the COOL dial and
-     * the top handle of the AUTO pair both show the target itself, keeping the two
-     * views in the same tone.
+     * The cooling threshold is the one and only temperature control:
+     * the COOL dial and the top handle of the AUTO pair both show the target itself,
+     * keeping the two views in the same tone.
      */
     private getDisplayCoolingThreshold(context: AirConditionerInterface): number {
         return this.getThresholdTemperature(context);
     }
 
     /**
-     * The heating threshold exists only so the Home app renders a temperature control
-     * in AUTO (it wants a heat/cool pair). It parks one degree BELOW the minimum
-     * target, so the cooling handle can travel the whole range in both directions —
-     * including down to the minimum itself; writes to it are dropped entirely
-     * (see the SET handler).
+     * The heating threshold exists only so the Home app renders a temperature control in AUTO
+     * (it wants a heat/cool pair).
+     * It parks one degree BELOW the minimum target,
+     * so the cooling handle can travel the whole range in both directions —
+     * including down to the minimum itself;
+     * writes to it are dropped entirely (see the SET handler).
      */
     private getDisplayHeatingThreshold(): number {
         return MIN_TEMPERATURE - 1;
@@ -233,28 +234,44 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
      * gets its UI reverted by the trailing sync in one pass.
      */
     private scheduleSync(accessory: PlatformAccessory) {
+        const gesture = this.gestureOf(this.getAccessoryInterface(accessory));
+        if(gesture.timer) {
+            clearTimeout(gesture.timer);
+        }
+        gesture.timer = setTimeout(() => this.flushGesture(accessory), GESTURE_WINDOW_MILLISECONDS);
+    }
+
+    /**
+     * Commit the debounced gesture now:
+     * apply the pending cooling write, sync the UI, and arm the guards.
+     * Extracted so an incoming push can force it before applying wallpad state —
+     * otherwise a push landing inside the debounce window would reflect ahead of the user's gesture,
+     * and the trailing task would then fight it.
+     * Committing first arms the command/temperature guards,
+     * which then suppress the (stale, pre-command) push that follows,
+     * keeping the user's intent authoritative.
+     */
+    private flushGesture(accessory: PlatformAccessory) {
         const context = this.getAccessoryInterface(accessory);
         const gesture = this.gestureOf(context);
         if(gesture.timer) {
             clearTimeout(gesture.timer);
-        }
-        gesture.timer = setTimeout(() => {
             gesture.timer = undefined;
-            const pending = gesture.pendingCool;
-            gesture.pendingCool = undefined;
-            if(pending !== undefined) {
-                this.applyThresholdTemperature(accessory, this.toWallPadTemperature(pending));
-            }
-            this.syncAccessoryState(accessory);
-            this.armCommandGuards(context);
-        }, GESTURE_WINDOW_MILLISECONDS);
+        }
+        const pending = gesture.pendingCool;
+        gesture.pendingCool = undefined;
+        if(pending !== undefined) {
+            this.applyThresholdTemperature(accessory, this.toWallPadTemperature(pending));
+        }
+        this.syncAccessoryState(accessory);
+        this.armCommandGuards(context);
     }
 
     /**
      * Arm the command + temperature guards from the just-committed optimistic context,
-     * so incoming pushes (see applyWallPadState) can tell our own command's settling
-     * from stale pre-command state. Called only from the user-action path (scheduleSync),
-     * never when applying wallpad state, so incoming state never re-arms the guards.
+     * so incoming pushes (see applyWallPadState) can tell our own command's settling from stale pre-command state.
+     * Called only from the user-action path (scheduleSync), never when applying wallpad state,
+     * so incoming state never re-arms the guards.
      */
     private armCommandGuards(context: AirConditionerInterface) {
         const gesture = this.gestureOf(context);
@@ -273,9 +290,9 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
     }
 
     /**
-     * WallPad state -> context, gated by the command + temperature guards. Mutates the
-     * existing context in place (unlike first-sight creation), so fields the op does not
-     * report — lastManualRotationSpeed, lastClimateMode — persist naturally.
+     * WallPad state -> context, gated by the command + temperature guards.
+     * Mutates the existing context in place (unlike first-sight creation),
+     * so fields the op does not report — lastManualRotationSpeed, lastClimateMode — persist naturally.
      */
     private applyWallPadState(accessory: PlatformAccessory, op: any) {
         const context = this.getAccessoryInterface(accessory);
@@ -297,10 +314,10 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
             }
         }
 
-        // Temperature re-assert guard: hold our target on screen and re-send it while the
-        // wallpad reports its own stored setpoint. Held for the whole window (never
-        // released on the first match) because the wallpad echoes our value once, then
-        // snaps back to its stored per-mode value.
+        // Temperature re-assert guard: hold our target on screen and re-send it
+        // while the wallpad reports its own stored setpoint.
+        // Held for the whole window (never released on the first match)
+        // because the wallpad echoes our value once, then snaps back to its stored per-mode value.
         let holdTemp = false;
         const incTemp = Number(op["desired_temp"] ?? op["set_temp"]);
         if(gesture.tempGuardUntil !== undefined && incPower && this.isClimateMode(incMode)) {
@@ -343,9 +360,9 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
     }
 
     /**
-     * Fire a standalone set_temp so the wallpad adopts our value even after it dropped
-     * the set_temp bundled with a mode change. Sent immediately (not deferred): the guard
-     * needs the correction to reach the wallpad within its window.
+     * Fire a standalone set_temp so the wallpad adopts our value
+     * even after it dropped the set_temp bundled with a mode change.
+     * Sent immediately (not deferred): the guard needs the correction to reach the wallpad within its window.
      */
     private reassertThresholdTemperature(context: AirConditionerInterface, mode: Mode, target: number) {
         const device = this.findDevice(context.deviceId);
@@ -511,8 +528,9 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         }
         const wind = this.homebridgeToRotationSpeed(numeric);
         if(!context.active) {
-            // The Home app often writes the slider just before Active=1 — remember the
-            // speed so the power-on that follows uses it, and revert the slider for now.
+            // The Home app often writes the slider just before Active=1 —
+            // remember the speed so the power-on that follows uses it,
+            // and revert the slider for now.
             context.lastManualRotationSpeed = wind;
             this.scheduleSync(accessory);
             callback(undefined);
@@ -558,10 +576,11 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
     }
 
     /**
-     * Migrate a context restored from an older cache: `lastManualRotationSpeed` and
-     * `lastClimateMode` did not exist before this rework, so a cached accessory carries
-     * them as undefined. Seed sane defaults before any handler can read them — otherwise
-     * powering on would command `mode: "undefined"` or throw on `undefined.toString()`.
+     * Migrate a context restored from an older cache:
+     * `lastManualRotationSpeed` and `lastClimateMode` did not exist before this rework,
+     * so a cached accessory carries them as undefined.
+     * Seed sane defaults before any handler can read them —
+     * otherwise powering on would command `mode: "undefined"` or throw on `undefined.toString()`.
      */
     private normalizeContext(context: AirConditionerInterface) {
         if(context.lastManualRotationSpeed === undefined) {
@@ -662,10 +681,10 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
 
         heaterCooler.getCharacteristic(this.api.hap.Characteristic.CoolingThresholdTemperature)
             .setProps({
-                // Matches the parked heating handle (min - 1): the Home app renders the
-                // AUTO pair on one shared track bounded by this range, and a floor of 18
-                // would clamp the parked handle up to 18 on every gesture. Targets still
-                // clamp into 18..30 on write.
+                // Matches the parked heating handle (min - 1):
+                // the Home app renders the AUTO pair on one shared track bounded by this range,
+                // and a floor of 18 would clamp the parked handle up to 18 on every gesture.
+                // Targets still clamp into 18..30 on write.
                 minValue: MIN_TEMPERATURE - 1,
                 maxValue: MAX_TEMPERATURE,
                 minStep: 1,
@@ -912,6 +931,11 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
                 if(existing) {
                     const kept = this.addOrGetAccessory(this.getAccessoryInterface(existing));
                     if(!kept) continue; // disabled -> unregistered
+                    // A gesture still mid-debounce must be committed before the push is applied,
+                    // so the user's intent lands (and arms the guards) first.
+                    if(this.gestureOf(this.getAccessoryInterface(kept)).timer) {
+                        this.flushGesture(kept);
+                    }
                     this.applyWallPadState(kept, device.op);
                     continue;
                 }

--- a/homebridge/accessories/smart-elife/air-conditioner.ts
+++ b/homebridge/accessories/smart-elife/air-conditioner.ts
@@ -302,9 +302,12 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         const reportedMode = (op["mode"] as Mode) || context.mode;
 
         // Command guard: drop stale pushes that still carry the pre-command power/mode.
+        // Mode is compared even when off: a mode picked while powered off is a local-only
+        // change (no command is sent), so a stale off-push carrying the previous mode must
+        // not confirm and overwrite it — otherwise the next power-on would use the old mode.
         if(gesture.pendingSince !== undefined) {
             const confirmed = reportedPower === gesture.pendingPower
-                && (!reportedPower || reportedMode === gesture.pendingMode);
+                && reportedMode === gesture.pendingMode;
             if(confirmed) {
                 gesture.pendingSince = undefined; // wallpad caught up — live again
             } else if(Date.now() - gesture.pendingSince < COMMAND_GUARD_MILLISECONDS) {


### PR DESCRIPTION
# Summary

This implements the rework proposed in #178. It moves the Smart eLife air conditioner accessory from HeaterCooler + HumidifierDehumidifier + AirPurifier to **HeaterCooler (primary) + Fanv2 + HumidifierDehumidifier**, addressing the four limitations raised there: fan speed disappearing in the combined tile, fan mode being represented as an air purifier, no temperature control in AUTO, and no way to express the cooling-mode `wind_speed: "auto"`. All wallpad→HomeKit state reflection moves to `updateCharacteristic` so SET handlers no longer re-enter and echo commands back to the wallpad.

# Changes

- **Service composition.** Replace AirPurifier with Fanv2 and make HeaterCooler the primary service. Fan mode is literally a fan, so Fanv2 fits its icon and Siri vocabulary; it also frees the AirPurifier type for households that install a real air purifier. Rejected: `addLinkedService` (it marked the fan/dehumidifier as sub-features and made the Home app suppress their controls in the separated-tile view); a single Thermostat service (its AUTO view still needs a threshold pair, and it cannot carry `RotationSpeed`, which would drop the fan control — verified against a Thermostat mockup).
- **Fan speed on both HeaterCooler and Fanv2.** Exposing `RotationSpeed` on both keeps the control working in the combined tile (unlike the AirPurifier duplicate, which the Home app cut) and in the separated tiles. `RotationSpeed` gains an `AUTO` value, and `TargetFanState` (MANUAL/AUTO) maps to `wind_speed: "auto"` ↔ the last manual speed — resolving limitation 4.
- **AUTO temperature UI.** HomeKit's AUTO view requires a heating/cooling threshold pair, so `HeatingThresholdTemperature` is added but parked at 17°C (one below the minimum) and never used as a control; the single cooling handle is the target (18–30, integer). Its writes are dropped and the UI reverts, with a late forced `sendEventNotification` because the Home app ignores an immediate correction that contradicts its own write. The cooling threshold's `minValue` is also 17 so the Home app's shared handle track reaches the park and stops clamping the bottom handle up on every gesture. Rejected: a 0.5° band (the Home app quantizes the handle pair to a 1° grid, collapsing it); pinning heating at 18 (then the top handle can't reach 18 itself).
- **Per-mode constraints mirror the native app.** AUTO = temperature only (wind is wallpad-managed; the slider parks at 100%); COOL = temperature + wind (including auto); DEHUMIDIFYING = power only; FAN = wind only (auto forbidden). Touching the wind slider while dehumidifying switches to fan mode at that speed rather than doing nothing.
- **State reflection via `updateCharacteristic`.** Every wallpad→HomeKit update uses `updateCharacteristic`, so SET handlers never re-enter and echo the command back to the wallpad (the previous `setCharacteristic` path could loop).
- **Guards for wallpad state quirks.** A *command guard* ignores stale pushes still carrying the pre-command power/mode for up to 7s or until the wallpad confirms. A *temperature re-assert guard* handles the wallpad dropping a `set_temp` bundled with a mode change and keeping its own stored per-mode setpoint: it holds the displayed target and re-sends a standalone `set_temp` (10s cap, 1s throttle), holding for the whole window rather than releasing on the first echo, because the wallpad echoes our value once and then snaps back to its stored value. Both guards arm only on user actions, never when applying incoming state.

# Migration

The AirPurifier service is removed and Fanv2 added automatically on the next restart (the base accessory drops services no longer in `serviceTypes`). No action is needed for the swap itself, but **automations or scenes bound to the old AirPurifier service — including its `RotationSpeed` — will break and must be recreated against the new Fanv2 service.** Automations bound to the HeaterCooler (power, temperature, fan speed) are preserved, since that service is unchanged.

The accessory context gained two fields (`lastManualRotationSpeed`, `lastClimateMode`). A context restored from an older cache lacks them, which would otherwise command `mode: "undefined"` or throw on `undefined.toString()` when powered on; a normalization step seeds safe defaults on load, so upgrades are transparent.

# Testing

- Confirmed against the live control page (`smartelife.apt.co.kr`): the four modes, the per-mode wind/temperature enable rules, and cooling-mode `wind_speed: "auto"`.
- A bridged mockup with the identical service composition was iterated on a iOS Home app (iPhone 17 Pro Max, iOS 26.5.2), covering combined vs. separated tile rendering, the threshold handle gestures and the app's untouched-handle rewrite, the 17° park letting the top handle reach 18, the dehumidifying→fan wind behavior, mode transitions, and both guards — including observing the temperature re-assert recover the setpoint after the wallpad snapped it back to its stored value.
- On the actual plugin: `npm run build` type-check passes, plus a runtime smoke exercising the four guard behaviors and the cached-context migration.
- **Not yet done:** running this plugin (as opposed to the mockup) against a live wallpad. Only the mockup was live-tested end to end.

Closes #178.