### PR TITLE
Fix Smart eLife cooktop lock state never being reflected back to HomeKit

### DIFF
--- a/homebridge/accessories/smart-elife/gas.ts
+++ b/homebridge/accessories/smart-elife/gas.ts
@@ -34,9 +34,7 @@ export default class GasAccessories extends Accessories<GasAccessoryInterface> {
             .getCharacteristic(this.api.hap.Characteristic.LockCurrentState)
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                callback(undefined, context.secured
-                    ? this.api.hap.Characteristic.LockCurrentState.SECURED
-                    : this.api.hap.Characteristic.LockCurrentState.UNSECURED);
+                callback(undefined, this.lockCurrentState(context));
             });
         this.getService(accessory, this.api.hap.Service.LockMechanism)
             .getCharacteristic(this.api.hap.Characteristic.LockTargetState)
@@ -52,7 +50,8 @@ export default class GasAccessories extends Accessories<GasAccessoryInterface> {
                     // Update the LockMechanism characteristic immediately.
                     setTimeout(() => {
                         this.getService(accessory, this.api.hap.Service.LockMechanism)
-                            .setCharacteristic(this.api.hap.Characteristic.LockTargetState, this.api.hap.Characteristic.LockTargetState.SECURED);
+                            .getCharacteristic(this.api.hap.Characteristic.LockTargetState)
+                            .updateValue(this.lockTargetState(this.getAccessoryInterface(accessory)));
                     }, 0);
                     callback(undefined);
                     return;
@@ -69,13 +68,33 @@ export default class GasAccessories extends Accessories<GasAccessoryInterface> {
                 }
                 context.secured = true;
                 callback(undefined);
+                this.updateLockState(accessory);
             })
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
-                callback(undefined, context.secured
-                    ? this.api.hap.Characteristic.LockTargetState.SECURED
-                    : this.api.hap.Characteristic.LockTargetState.UNSECURED);
+                callback(undefined, this.lockTargetState(context));
             });
+    }
+
+    private lockCurrentState(context: GasAccessoryInterface): CharacteristicValue {
+        return context.secured
+            ? this.api.hap.Characteristic.LockCurrentState.SECURED
+            : this.api.hap.Characteristic.LockCurrentState.UNSECURED;
+    }
+
+    private lockTargetState(context: GasAccessoryInterface): CharacteristicValue {
+        return context.secured
+            ? this.api.hap.Characteristic.LockTargetState.SECURED
+            : this.api.hap.Characteristic.LockTargetState.UNSECURED;
+    }
+
+    private updateLockState(accessory: PlatformAccessory) {
+        const context = this.getAccessoryInterface(accessory);
+        const lock = this.getService(accessory, this.api.hap.Service.LockMechanism);
+        lock.getCharacteristic(this.api.hap.Characteristic.LockCurrentState)
+            .updateValue(this.lockCurrentState(context));
+        lock.getCharacteristic(this.api.hap.Characteristic.LockTargetState)
+            .updateValue(this.lockTargetState(context));
     }
 
     register() {
@@ -91,11 +110,7 @@ export default class GasAccessories extends Accessories<GasAccessoryInterface> {
                 });
                 if(!accessory) continue;
 
-                const context = this.getAccessoryInterface(accessory);
-                const service = accessory.getService(this.api.hap.Service.LockMechanism);
-                service?.setCharacteristic(this.api.hap.Characteristic.LockTargetState, context.secured
-                    ? this.api.hap.Characteristic.LockTargetState.SECURED
-                    : this.api.hap.Characteristic.LockTargetState.UNSECURED);
+                this.updateLockState(accessory);
             }
         });
     }


### PR DESCRIPTION
# Summary

The Smart eLife cooktop (gas) accessory accepted lock commands correctly — the wallpad locked the cooktop — but the resulting lock state never reached HomeKit: the Home app stayed on "Locking…" after locking, and open/close changes made from the wallpad or the native app were never reflected. This change makes the accessory push lock state updates to HomeKit. Fixes #180.

# Root cause

In `homebridge/accessories/smart-elife/gas.ts`, `LockCurrentState` only had a GET handler and was never updated through `updateCharacteristic`/`updateValue` anywhere, and HomeKit is event-driven, so controllers never learned about state changes. On the wallpad event path, the device listener in `register()` replaced the accessory context with the new state first and then called `setCharacteristic(LockTargetState, ...)`, which re-enters the `LockTargetState` SET handler only to hit the `context.secured === secured` early-return guard — effectively a no-op. On the HomeKit-initiated path, the SET handler recorded `context.secured = true` after a successful `close` control but never raised `LockCurrentState` to SECURED, leaving the lock transition unfinished from the controller's point of view.

# Changes

- Added an `updateLockState()` helper that pushes both `LockCurrentState` and `LockTargetState` through `updateValue`, following the pattern already proven by the smart door lock accessory (`updateSmartDoorState()` in `door.ts`). Because `updateValue` does not invoke SET handlers, there is no path for commands to be re-emitted (echoed) to the wallpad.
- The device listener now calls `updateLockState()` instead of `setCharacteristic(LockTargetState, ...)`, so wallpad-side open/close events are reflected in HomeKit.
- The `LockTargetState` SET handler calls `updateLockState()` after a successful `close` control, so the Home app transitions from "Locking…" to "Locked".
- The unsecure-revert path now restores `LockTargetState` with `updateValue` instead of `setCharacteristic`, and the GET handlers share the new `lockCurrentState()`/`lockTargetState()` helpers. The device type stays `LockMechanism`; switching to Valve/Switch was considered and rejected (no HomeKit gas-valve service exists, Valve implies an "open" primary action that a remote-lock-only device cannot honor, and a service type change would break existing users' automations and scenes).

# Testing

- `npm run build` type check passes.
- Verified on a real household (production Homebridge on a Raspberry Pi with an installed cooktop): locking from the Home app made the wallpad acknowledge the control (`control_response`), the subsequent `event_gas` push reported `status: "close"`, and the Home app transitioned to "Locked"; opening the cooktop externally was reflected as unlocked in HomeKit via the `event_gas` `status: "open"` push; locking it again externally was reflected back as locked.
- Confirmed from debug logs that no gas control commands were re-emitted after state events (no command echo to the wallpad).