### PR TITLE
Handle the new Smart eLife push payload format and add a communal door motion sensor

### DIFF
--- a/core/interfaces/smart-elife-config.ts
+++ b/core/interfaces/smart-elife-config.ts
@@ -91,4 +91,24 @@ export enum PushType {
     VISITOR = "5-32",
     CAR = "5-46",
     FRONT_DOOR = "5-61",
+
+    // Not a wire-format value. The access (출입) push category covers both the
+    // household front door and the communal door; parsing resolves to this type
+    // when the notification body points to the communal door.
+    COMMUNAL_DOOR = "communal-door",
 }
+
+// Since July 2026 the server sends a single `data4` code instead of the legacy
+// data1/data2/data3 JSON payload. Only codes observed in the wild are mapped here;
+// unknown codes fall back to matching the notification title (`TITLE_PUSH_TYPES`).
+export const DATA4_PUSH_TYPES: { [code: string]: PushType } = {
+    "58": PushType.CAR, // 입출차: "등록 ... 차량이 입차하였습니다."
+    "64": PushType.FRONT_DOOR, // 출입: "공동 현관 출입이 감지되었습니다." (refined by body into COMMUNAL_DOOR)
+};
+
+// Fallback mapping for unmapped `data4` codes. The titles are the same category
+// names that appear in /mypage/pushList.ajax (push_car: "입출차", push_door: "출입 알림").
+export const TITLE_PUSH_TYPES: { [title: string]: PushType } = {
+    "입출차": PushType.CAR,
+    "출입": PushType.FRONT_DOOR,
+};

--- a/core/interfaces/smart-elife-config.ts
+++ b/core/interfaces/smart-elife-config.ts
@@ -55,33 +55,27 @@ export interface PushItem {
     desc?: string
 }
 
+// The server renamed the push setting item keys around July 2026 (e.g. `car` -> `push_car`,
+// `smartdoorstatus` -> `push_doorlock`), alongside the push payload format change. The values
+// below are the keys /mypage/pushList.ajax currently returns. The legacy `visitor` and
+// `familyenter` kinds have no observed equivalent in the new list.
 export enum PushItemKind {
     UNKNOWN = "unknown",
-    GAS = "gas",
-    FAMILY_ENTER = "familyenter",
-    NEW_BOARD = "boardnew",
-    ENTRANCE_PASSWORD_CHANGE = "entpw",
-    NEW_NOTICE = "notice",
-    HEATING = "heating",
-    WALL_SOCKET = "wallsocket",
-    SMART_DOOR_STATUS = "smartdoorstatus",
-    SECURITY = "OUTING",
-    SECURITY_PASSWORD_CHANGE = "secpw",
-    VISITOR = "visitor",
-    MODE_RUNNING = "moderun",
-    AIR_CONDITIONER = "aircon",
-    EMS = "ems",
-    ELEVATOR = "elevator",
-    ALL_OFF_SWITCH = "allofswitch",
-    ONE_TIME_KEY = "onetimekey",
-    CAR = "car",
-    LIGHT = "light",
-    DOOR = "door",
-    CARE_SERVICE = "careservice",
-    PARCEL = "parcel",
-    VENT = "vent",
-    NEW_USER = "usernew",
-    UNREGISTER_USER = "userout",
+    NOTICE = "push_notice",
+    DOOR_LOCK = "push_doorlock",
+    MODE_RUNNING = "push_mode",
+    PASSWORD_CHANGE = "push_change_pw",
+    INDOOR_AIR = "push_indoorair",
+    EMS = "push_ems",
+    CAR = "push_car",
+    EV = "push_ev",
+    CONTROL = "push_control",
+    PARKING_LOT = "push_parking_lot",
+    DOOR = "push_door",
+    PARCEL = "push_parcel",
+    MEMBER = "push_member",
+    // FAMILY_ENTER = "familyenter",
+    // VISITOR = "visitor",
 }
 
 export enum PushType {
@@ -102,6 +96,7 @@ export enum PushType {
 // data1/data2/data3 JSON payload. Only codes observed in the wild are mapped here;
 // unknown codes fall back to matching the notification title (`TITLE_PUSH_TYPES`).
 export const DATA4_PUSH_TYPES: { [code: string]: PushType } = {
+    "55": PushType.FRONT_DOOR, // 도어락: "수동에 의하여 문이 열렸습니다." (sent only when push_doorlock is enabled)
     "58": PushType.CAR, // 입출차: "등록 ... 차량이 입차하였습니다."
     "64": PushType.FRONT_DOOR, // 출입: "공동 현관 출입이 감지되었습니다." (refined by body into COMMUNAL_DOOR)
 };

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -2,12 +2,14 @@ import fetch, {Response} from "node-fetch";
 import {LoggerBase, Utils} from "../utils";
 import {
     ControlQueryCategory,
+    DATA4_PUSH_TYPES,
     Device,
     DeviceType,
     PushItem,
     PushItemKind,
     PushType,
-    SmartELifeConfig
+    SmartELifeConfig,
+    TITLE_PUSH_TYPES
 } from "../interfaces/smart-elife-config";
 import {ClientResponseCode} from "./responses";
 import PushReceiver from "@eneris/push-receiver";
@@ -593,33 +595,68 @@ export default class SmartELifeClient {
         return Utils.aes256Base64(this.config.uuid, this.key, this.iv);
     }
 
+    private parsePushType(data: { [key: string]: unknown } | undefined, title?: string, body?: string): PushType {
+        const pushType = this.parseRawPushType(data, title);
+        // The access (출입) push category covers both the household front door and
+        // the communal door; only the notification body tells them apart.
+        if(pushType === PushType.FRONT_DOOR && !!body && body.includes("공동")) {
+            return PushType.COMMUNAL_DOOR;
+        }
+        return pushType;
+    }
+
+    private parseRawPushType(data: { [key: string]: unknown } | undefined, title?: string): PushType {
+        if(!data) {
+            return PushType.UNKNOWN;
+        }
+        // Legacy payload: `data` holds a JSON string whose data1/data2/data3
+        // fields are joined into the PushType key (e.g. "5-46").
+        if(data["data"]) {
+            let payload: any;
+            try {
+                payload = JSON.parse(data["data"] as string);
+            } catch {
+                return PushType.UNKNOWN;
+            }
+            if(!payload) {
+                return PushType.UNKNOWN;
+            }
+            const pushTypeString = ["data1", "data2", "data3"]
+                .map((key) => payload[key])
+                .filter((value) => !!value)
+                .join("-");
+            return pushTypeString as PushType || PushType.UNKNOWN;
+        }
+        // Current payload (since July 2026): a single `data4` code.
+        if(data["data4"]) {
+            const pushType = DATA4_PUSH_TYPES[String(data["data4"])];
+            if(pushType) {
+                return pushType;
+            }
+        }
+        // Unmapped code; fall back to the notification title which carries
+        // the push category name.
+        if(title && TITLE_PUSH_TYPES[title]) {
+            return TITLE_PUSH_TYPES[title];
+        }
+        return PushType.UNKNOWN;
+    }
+
     private async configurePushNotification() {
         if(this.push) {
             this.log("Configuring Push");
 
             this.push.onNotification((notification) => {
                 this.log.info(`[Push] onNotify (JSON): ${JSON.stringify(notification.message, null, 2)}`);
-                const data = notification.message.data;
-                if(!data || !data["data"]) {
-                    this.log.warn("Unexpected Push message (no data): %s", JSON.stringify(notification.message));
-                    return;
-                }
-                const payload = JSON.parse(data["data"] as string);
-                if(!payload) {
-                    this.log.warn("Unexpected Push message (not JSON): %s", JSON.stringify(notification.message));
-                    return;
-                }
-                const pushTypeString = ["data1", "data2", "data3"]
-                    .map((key) => payload[key])
-                    .filter((value) => !!value)
-                    .join("-");
-                const pushType = pushTypeString as PushType || PushType.UNKNOWN;
+                const message = notification.message;
+                const title = message.notification?.title;
+                const body = message.notification?.body;
+
+                const pushType = this.parsePushType(message.data, title, body);
                 if(pushType === PushType.UNKNOWN) {
-                    this.log.warn("Unexpected Push message (unknown payload): %s", JSON.stringify(notification.message));
+                    this.log.warn("Unexpected Push message (unknown payload): %s", JSON.stringify(message));
                     return;
                 }
-                const title = notification.message.notification?.title;
-                const body = notification.message.notification?.body;
 
                 for(const listener of this.pushListeners) {
                     if(listener.pushType !== pushType) continue;

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -750,12 +750,12 @@ export default class SmartELifeClient {
             this.log("Push notification configured.");
 
             const items = await this.checkPushSettings();
+            // The legacy VISITOR and FAMILY_ENTER kinds are dropped here because the
+            // renamed setting list exposes no equivalent items.
             await this.setPushActive(items, [
-                PushItemKind.VISITOR,
-                PushItemKind.CAR,
-                PushItemKind.DOOR,
-                PushItemKind.FAMILY_ENTER,
-                PushItemKind.SMART_DOOR_STATUS,
+                PushItemKind.CAR, // vehicle in/out motion (data4 58)
+                PushItemKind.DOOR, // communal/front door access motion (data4 64)
+                PushItemKind.DOOR_LOCK, // front door open motion (data4 55)
             ]);
         });
 

--- a/homebridge-ui/providers/smart-elife.ts
+++ b/homebridge-ui/providers/smart-elife.ts
@@ -8,7 +8,7 @@ import {Logging} from "homebridge";
 import Timeout = NodeJS.Timeout;
 import {WALLPAD_VERSION_3_0} from "../../core/smart-elife/parsers/version-parsers";
 import {EXTERIOR_ELEVATOR_DEVICE} from "../../homebridge/accessories/smart-elife/elevator";
-import {EXTERIOR_FRONT_DOOR_DEVICE} from "../../homebridge/accessories/smart-elife/door";
+import {EXTERIOR_COMMUNAL_DOOR_DEVICE, EXTERIOR_FRONT_DOOR_DEVICE} from "../../homebridge/accessories/smart-elife/door";
 import {EXTERIOR_VEHICLE_BARRIER_DEVICE} from "../../homebridge/accessories/smart-elife/vehicle";
 import {
     EXTERIOR_COMMUNAL_DOOR_CAMERA_DEVICE,
@@ -33,7 +33,7 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
         const devices = await this.fetchIndoorAirQualityDevices();
         devices.push(EXTERIOR_ELEVATOR_DEVICE);
         devices.push(EXTERIOR_FRONT_DOOR_DEVICE);
-        // devices.push(EXTERIOR_COMMUNAL_DOOR_DEVICE);
+        devices.push(EXTERIOR_COMMUNAL_DOOR_DEVICE);
         devices.push(EXTERIOR_VEHICLE_BARRIER_DEVICE);
         devices.push(EXTERIOR_FRONT_DOOR_CAMERA_DEVICE);
         devices.push(EXTERIOR_COMMUNAL_DOOR_CAMERA_DEVICE);

--- a/homebridge-ui/providers/smart-elife.ts
+++ b/homebridge-ui/providers/smart-elife.ts
@@ -8,7 +8,7 @@ import {Logging} from "homebridge";
 import Timeout = NodeJS.Timeout;
 import {WALLPAD_VERSION_3_0} from "../../core/smart-elife/parsers/version-parsers";
 import {EXTERIOR_ELEVATOR_DEVICE} from "../../homebridge/accessories/smart-elife/elevator";
-import {EXTERIOR_COMMUNAL_DOOR_DEVICE, EXTERIOR_FRONT_DOOR_DEVICE} from "../../homebridge/accessories/smart-elife/door";
+import {EXTERIOR_DOOR_DEVICES} from "../../homebridge/accessories/smart-elife/door";
 import {EXTERIOR_VEHICLE_BARRIER_DEVICE} from "../../homebridge/accessories/smart-elife/vehicle";
 import {
     EXTERIOR_COMMUNAL_DOOR_CAMERA_DEVICE,
@@ -32,8 +32,9 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
     async configureInitialDevices(): Promise<Device[]> {
         const devices = await this.fetchIndoorAirQualityDevices();
         devices.push(EXTERIOR_ELEVATOR_DEVICE);
-        devices.push(EXTERIOR_FRONT_DOOR_DEVICE);
-        devices.push(EXTERIOR_COMMUNAL_DOOR_DEVICE);
+        for(const device of EXTERIOR_DOOR_DEVICES) {
+            devices.push(device);
+        }
         devices.push(EXTERIOR_VEHICLE_BARRIER_DEVICE);
         devices.push(EXTERIOR_FRONT_DOOR_CAMERA_DEVICE);
         devices.push(EXTERIOR_COMMUNAL_DOOR_CAMERA_DEVICE);

--- a/homebridge/accessories/smart-elife/accessories.ts
+++ b/homebridge/accessories/smart-elife/accessories.ts
@@ -97,7 +97,7 @@ export default class Accessories<T extends AccessoryInterface> {
 
         const removals = [];
         for(const service of accessory.services) {
-            if(this.isSupportedService(service)) {
+            if(this.isSupportedService(service, accessory)) {
                 continue;
             }
             this.log.debug("The service %s is no longer supported from accessory: %s (%s)", service.constructor.name, context.displayName, this.deviceType.toString());
@@ -114,7 +114,7 @@ export default class Accessories<T extends AccessoryInterface> {
         this.log.info("Identifying %s", accessory.displayName);
     }
 
-    private isSupportedService(service: Service): boolean {
+    protected isSupportedService(service: Service, _: PlatformAccessory): boolean {
         for(const t of this.serviceTypes) {
             if(t.UUID === service.UUID) {
                 return true;
@@ -123,7 +123,7 @@ export default class Accessories<T extends AccessoryInterface> {
         return false;
     }
 
-    private isSupportedServiceType(serviceType: ServiceType): boolean {
+    protected isSupportedServiceType(serviceType: ServiceType, _: PlatformAccessory): boolean {
         for(const t of this.serviceTypes) {
             if(t.UUID === serviceType.UUID) {
                 return true;
@@ -133,7 +133,7 @@ export default class Accessories<T extends AccessoryInterface> {
     }
 
     protected getService(accessory: PlatformAccessory, serviceType: ServiceType): Service {
-        if(!this.isSupportedServiceType(serviceType)) {
+        if(!this.isSupportedServiceType(serviceType, accessory)) {
             throw new Error(`Service \`${serviceType.name}\` is not registered as a supported service type in \`${this.deviceType.toString()}\` accessories.`);
         }
         const context = this.getAccessoryInterface(accessory);

--- a/homebridge/accessories/smart-elife/accessories.ts
+++ b/homebridge/accessories/smart-elife/accessories.ts
@@ -15,7 +15,8 @@ export interface DeviceWithOp extends Device {
     op: any;
 }
 
-export type DeviceListener = (devices: DeviceWithOp[]) => void;
+export type NonEmptyDeviceList = [DeviceWithOp, ...DeviceWithOp[]];
+export type DeviceListener = (devices: NonEmptyDeviceList) => void;
 export type ServiceType = WithUUID<typeof Service>;
 
 const DEFERRED_TASKS_MILLISECONDS = 500;
@@ -194,10 +195,18 @@ export default class Accessories<T extends AccessoryInterface> {
             } else {
                 devices = this.parseDevices(data, deviceType);
             }
-            if(devices.length === 0)
-                this.log.warn("No devices op received for %s. Are the devices disconnected from WallPad?", deviceType.toString());
+            // The wallpad can return no devices, and broadcasts for other households can leave
+            // no locally configured devices after parsing. Neither case carries device state for
+            // this listener but retains the signal at debug level for troubleshooting.
+            if(devices.length === 0) {
+                if(data && Array.isArray(data["devices"])) {
+                    this.log.debug("Ignoring %s listener event: %d device(s) received and no configured device state was available.",
+                        deviceType.toString(), data["devices"].length);
+                }
+                return;
+            }
 
-            deviceListener(devices);
+            deviceListener(devices as NonEmptyDeviceList);
         }, deviceType);
     }
 

--- a/homebridge/accessories/smart-elife/door.ts
+++ b/homebridge/accessories/smart-elife/door.ts
@@ -27,13 +27,13 @@ export const EXTERIOR_FRONT_DOOR_DEVICE: Device = {
     deviceId: "CMFDOR001",
     disabled: false,
 };
-// export const EXTERIOR_COMMUNAL_DOOR_DEVICE: Device = {
-//     displayName: "외부 공동현관",
-//     name: "공동현관",
-//     deviceType: DeviceType.DOOR,
-//     deviceId: "CMFDOR002",
-//     disabled: false,
-// }
+export const EXTERIOR_COMMUNAL_DOOR_DEVICE: Device = {
+    displayName: "외부 공동현관",
+    name: "공동현관",
+    deviceType: DeviceType.DOOR,
+    deviceId: "CMFDOR002",
+    disabled: false,
+};
 export const DOOR_TIMEOUT_DURATION_SECONDS = 5; // 5 seconds
 const LOW_BATTERY_THRESHOLD = 20;
 
@@ -73,12 +73,14 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                 callback(undefined, context.motionDetected);
             });
 
-        if(!this.smartDoorDevice) {
+        const context = this.getAccessoryInterface(accessory);
+        // Only the household front door mirrors the smart door lock; the communal
+        // door has no control channel and stays a motion-only accessory.
+        if(!this.smartDoorDevice || context.deviceId !== EXTERIOR_FRONT_DOOR_DEVICE.deviceId) {
             this.removeSmartDoorServices(accessory);
             return;
         }
 
-        const context = this.getAccessoryInterface(accessory);
         context.smartDoorDeviceId = this.smartDoorDevice.deviceId;
 
         const lock = this.getService(accessory, this.api.hap.Service.LockMechanism);
@@ -167,14 +169,15 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
         return Math.max(0, Math.min(100, Math.round(level)));
     }
 
-    private ensureDoorAccessory(): PlatformAccessory | undefined {
-        const device = this.findDevice(EXTERIOR_FRONT_DOOR_DEVICE.deviceId);
+    private ensureDoorAccessory(doorDevice: Device): PlatformAccessory | undefined {
+        const device = this.findDevice(doorDevice.deviceId);
         if(!device) return undefined;
 
         const existing = this.findAccessory(device.deviceId);
         const context = existing
             ? this.getAccessoryInterface(existing)
             : undefined;
+        const isFrontDoor = doorDevice.deviceId === EXTERIOR_FRONT_DOOR_DEVICE.deviceId;
         return this.addOrGetAccessory({
             deviceId: device.deviceId,
             deviceType: device.deviceType,
@@ -182,9 +185,9 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             init: true,
             motionTimer: context?.motionTimer,
             motionDetected: context?.motionDetected ?? false,
-            smartDoorDeviceId: this.smartDoorDevice?.deviceId,
-            secured: context?.secured,
-            batteryLevel: context?.batteryLevel,
+            smartDoorDeviceId: isFrontDoor ? this.smartDoorDevice?.deviceId : undefined,
+            secured: isFrontDoor ? context?.secured : undefined,
+            batteryLevel: isFrontDoor ? context?.batteryLevel : undefined,
         });
     }
 
@@ -225,7 +228,7 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                 this.log.warn("Unknown device: %s", doorDevice.deviceId);
                 return;
             }
-            const accessory = this.ensureDoorAccessory();
+            const accessory = this.ensureDoorAccessory(doorDevice);
             if(!accessory) {
                 this.log.warn("Unknown accessory: %s", device.deviceId);
                 return;
@@ -257,6 +260,7 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
     register() {
         super.register();
         this.registerPushListener(PushType.FRONT_DOOR, EXTERIOR_FRONT_DOOR_DEVICE);
+        this.registerPushListener(PushType.COMMUNAL_DOOR, EXTERIOR_COMMUNAL_DOOR_DEVICE);
 
         if(this.smartDoorDevice) {
             this.addDeviceListener((devices) => {
@@ -264,14 +268,15 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                     .find((device) => device.deviceId === this.smartDoorDevice?.deviceId);
                 if(!smartDoor) return;
 
-                const accessory = this.ensureDoorAccessory();
+                const accessory = this.ensureDoorAccessory(EXTERIOR_FRONT_DOOR_DEVICE);
                 if(!accessory) return;
                 this.updateSmartDoorState(accessory, smartDoor.op);
             }, DeviceType.SMART_DOOR);
         }
 
         setTimeout(() => {
-            this.ensureDoorAccessory();
+            this.ensureDoorAccessory(EXTERIOR_FRONT_DOOR_DEVICE);
+            this.ensureDoorAccessory(EXTERIOR_COMMUNAL_DOOR_DEVICE);
         }, 1000);
     }
 }

--- a/homebridge/accessories/smart-elife/door.ts
+++ b/homebridge/accessories/smart-elife/door.ts
@@ -1,13 +1,12 @@
-import Accessories, {AccessoryInterface} from "./accessories";
+import Accessories, {AccessoryInterface, ServiceType} from "./accessories";
 import {
     API,
     CharacteristicEventTypes,
     CharacteristicGetCallback,
-    CharacteristicSetCallback,
     CharacteristicValue,
     HAPStatus,
     Logging,
-    PlatformAccessory,
+    PlatformAccessory, Service,
 } from "homebridge";
 import {Device, DeviceType, PushType, SmartELifeConfig} from "../../../core/interfaces/smart-elife-config";
 import Timeout = NodeJS.Timeout;
@@ -15,53 +14,66 @@ import Timeout = NodeJS.Timeout;
 interface DoorAccessoryInterface extends AccessoryInterface {
     motionTimer?: Timeout
     motionDetected: boolean
-    smartDoorDeviceId?: string
-    secured?: boolean
+    isSmartDoorLock?: boolean
     batteryLevel?: number
 }
 
-export const EXTERIOR_FRONT_DOOR_DEVICE: Device = {
-    displayName: "외부 세대현관",
-    name: "세대현관",
-    deviceType: DeviceType.DOOR,
-    deviceId: "CMFDOR001",
-    disabled: false,
-};
-export const EXTERIOR_COMMUNAL_DOOR_DEVICE: Device = {
-    displayName: "외부 공동현관",
-    name: "공동현관",
-    deviceType: DeviceType.DOOR,
-    deviceId: "CMFDOR002",
-    disabled: false,
-};
+interface DoorDevice extends Device {
+    isSmartDoorLock: boolean
+    pushType: PushType
+}
+
+export const EXTERIOR_DOOR_DEVICES: DoorDevice[] = [
+    {
+        displayName: "외부 세대현관",
+        name: "세대현관",
+        deviceType: DeviceType.DOOR,
+        deviceId: "CMFDOR001",
+        disabled: false,
+        isSmartDoorLock: true,
+        pushType: PushType.FRONT_DOOR,
+    },
+    {
+        displayName: "외부 공동현관",
+        name: "공동현관",
+        deviceType: DeviceType.DOOR,
+        deviceId: "CMFDOR002",
+        disabled: false,
+        isSmartDoorLock: false,
+        pushType: PushType.COMMUNAL_DOOR,
+    },
+];
+
 export const DOOR_TIMEOUT_DURATION_SECONDS = 5; // 5 seconds
 const LOW_BATTERY_THRESHOLD = 20;
 
 export default class DoorAccessories extends Accessories<DoorAccessoryInterface> {
-    private readonly smartDoorDevice?: Device;
 
     constructor(log: Logging, api: API, config: SmartELifeConfig) {
-        super(log, api, config, DeviceType.DOOR, [
-            api.hap.Service.MotionSensor,
-            api.hap.Service.LockMechanism,
-            api.hap.Service.Battery,
-        ]);
-
-        const smartDoorDevices = config.devices
-            .filter((device) => device.deviceType === DeviceType.SMART_DOOR && !device.disabled);
-        this.smartDoorDevice = smartDoorDevices[0];
-        if(smartDoorDevices.length > 1) {
-            this.log.warn(
-                "Multiple smartdoor devices are configured; using %s as the lock state source for %s.",
-                this.smartDoorDevice.deviceId,
-                EXTERIOR_FRONT_DOOR_DEVICE.deviceId,
-            );
-        }
+        super(log, api, config, DeviceType.DOOR, [api.hap.Service.MotionSensor, api.hap.Service.Battery]);
     }
 
     protected async identify(accessory: PlatformAccessory): Promise<void> {
         await super.identify(accessory);
         this.log.warn("Identifying `door` not supported.");
+    }
+
+    protected isSupportedServiceType(serviceType: ServiceType, accessory: PlatformAccessory): boolean {
+        const context = this.getAccessoryInterface(accessory);
+        if(context.isSmartDoorLock) {
+            return super.isSupportedServiceType(serviceType, accessory);
+        }
+        // Communal door only supports MotionSensor service type.
+        return serviceType.UUID === this.api.hap.Service.MotionSensor.UUID;
+    }
+
+    protected isSupportedService(service: Service, accessory: PlatformAccessory): boolean {
+        const context = this.getAccessoryInterface(accessory);
+        if(context.isSmartDoorLock) {
+            return super.isSupportedService(service, accessory);
+        }
+        // Communal door only supports MotionSensor service.
+        return service.UUID === this.api.hap.Service.MotionSensor.UUID;
     }
 
     configureAccessory(accessory: PlatformAccessory) {
@@ -74,36 +86,11 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             });
 
         const context = this.getAccessoryInterface(accessory);
-        // Only the household front door mirrors the smart door lock; the communal
-        // door has no control channel and stays a motion-only accessory.
-        if(!this.smartDoorDevice || context.deviceId !== EXTERIOR_FRONT_DOOR_DEVICE.deviceId) {
-            this.removeSmartDoorServices(accessory);
+        if(!context.isSmartDoorLock) {
             return;
         }
 
-        context.smartDoorDeviceId = this.smartDoorDevice.deviceId;
-
-        const lock = this.getService(accessory, this.api.hap.Service.LockMechanism);
-        lock.setPrimaryService(true);
-        lock.getCharacteristic(this.api.hap.Characteristic.LockCurrentState)
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                const context = this.getAccessoryInterface(accessory);
-                callback(undefined, this.lockCurrentState(context));
-            });
-        lock.getCharacteristic(this.api.hap.Characteristic.LockTargetState)
-            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
-                const context = this.getAccessoryInterface(accessory);
-                callback(undefined, this.lockTargetState(context));
-            })
-            .on(CharacteristicEventTypes.SET, (_value: CharacteristicValue, callback: CharacteristicSetCallback) => {
-                const context = this.getAccessoryInterface(accessory);
-                setTimeout(() => {
-                    this.getService(accessory, this.api.hap.Service.LockMechanism)
-                        .getCharacteristic(this.api.hap.Characteristic.LockTargetState)
-                        .updateValue(this.lockTargetState(context));
-                }, 0);
-                callback(HAPStatus.READ_ONLY_CHARACTERISTIC);
-            });
+        // `LockMechanism` service is discarded.
 
         const battery = this.getService(accessory, this.api.hap.Service.Battery);
         battery.getCharacteristic(this.api.hap.Characteristic.BatteryLevel)
@@ -130,28 +117,6 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             });
     }
 
-    private removeSmartDoorServices(accessory: PlatformAccessory) {
-        for(const serviceType of [this.api.hap.Service.LockMechanism, this.api.hap.Service.Battery]) {
-            const service = accessory.getService(serviceType);
-            if(service) accessory.removeService(service);
-        }
-    }
-
-    private lockCurrentState(context: DoorAccessoryInterface): CharacteristicValue {
-        if(context.secured === undefined) {
-            return this.api.hap.Characteristic.LockCurrentState.UNKNOWN;
-        }
-        return context.secured
-            ? this.api.hap.Characteristic.LockCurrentState.SECURED
-            : this.api.hap.Characteristic.LockCurrentState.UNSECURED;
-    }
-
-    private lockTargetState(context: DoorAccessoryInterface): CharacteristicValue {
-        return context.secured === false
-            ? this.api.hap.Characteristic.LockTargetState.UNSECURED
-            : this.api.hap.Characteristic.LockTargetState.SECURED;
-    }
-
     private lowBatteryState(batteryLevel: number): CharacteristicValue {
         return batteryLevel <= LOW_BATTERY_THRESHOLD
             ? this.api.hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
@@ -169,7 +134,7 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
         return Math.max(0, Math.min(100, Math.round(level)));
     }
 
-    private ensureDoorAccessory(doorDevice: Device): PlatformAccessory | undefined {
+    private addOrGetDoorAccessory(doorDevice: DoorDevice): PlatformAccessory | undefined {
         const device = this.findDevice(doorDevice.deviceId);
         if(!device) return undefined;
 
@@ -177,7 +142,6 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
         const context = existing
             ? this.getAccessoryInterface(existing)
             : undefined;
-        const isFrontDoor = doorDevice.deviceId === EXTERIOR_FRONT_DOOR_DEVICE.deviceId;
         return this.addOrGetAccessory({
             deviceId: device.deviceId,
             deviceType: device.deviceType,
@@ -185,32 +149,15 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             init: true,
             motionTimer: context?.motionTimer,
             motionDetected: context?.motionDetected ?? false,
-            smartDoorDeviceId: isFrontDoor ? this.smartDoorDevice?.deviceId : undefined,
-            secured: isFrontDoor ? context?.secured : undefined,
-            batteryLevel: isFrontDoor ? context?.batteryLevel : undefined,
+            isSmartDoorLock: doorDevice.isSmartDoorLock,
+            batteryLevel: doorDevice.isSmartDoorLock ? context?.batteryLevel : undefined,
         });
     }
 
-    private updateSmartDoorState(accessory: PlatformAccessory, operation: any) {
+    private refreshSmartDoorLockState(accessory: PlatformAccessory, op: any) {
         const context = this.getAccessoryInterface(accessory);
-        const status = operation?.["status"];
-        if(status === "open") {
-            context.secured = false;
-        } else if(status === "close") {
-            context.secured = true;
-        } else {
-            this.log.debug("Ignoring unknown smartdoor status: %s", String(status));
-        }
 
-        const lock = accessory.getService(this.api.hap.Service.LockMechanism);
-        lock?.getCharacteristic(this.api.hap.Characteristic.LockCurrentState)
-            .updateValue(this.lockCurrentState(context));
-        if(context.secured !== undefined) {
-            lock?.getCharacteristic(this.api.hap.Characteristic.LockTargetState)
-                .updateValue(this.lockTargetState(context));
-        }
-
-        const parsedBatteryLevel = this.parseBatteryLevel(operation?.["battery"]);
+        const parsedBatteryLevel = this.parseBatteryLevel(op?.["battery"]);
         if(parsedBatteryLevel === undefined) return;
 
         context.batteryLevel = parsedBatteryLevel;
@@ -221,14 +168,14 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             .updateValue(this.lowBatteryState(context.batteryLevel));
     }
 
-    registerPushListener(pushType: PushType, doorDevice: Device) {
-        this.addPushListener(pushType, () => {
+    registerPushListener(doorDevice: DoorDevice) {
+        this.addPushListener(doorDevice.pushType, () => {
             const device = this.findDevice(doorDevice.deviceId);
             if(!device) {
                 this.log.warn("Unknown device: %s", doorDevice.deviceId);
                 return;
             }
-            const accessory = this.ensureDoorAccessory(doorDevice);
+            const accessory = this.addOrGetDoorAccessory(doorDevice);
             if(!accessory) {
                 this.log.warn("Unknown accessory: %s", device.deviceId);
                 return;
@@ -259,24 +206,29 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
 
     register() {
         super.register();
-        this.registerPushListener(PushType.FRONT_DOOR, EXTERIOR_FRONT_DOOR_DEVICE);
-        this.registerPushListener(PushType.COMMUNAL_DOOR, EXTERIOR_COMMUNAL_DOOR_DEVICE);
-
-        if(this.smartDoorDevice) {
-            this.addDeviceListener((devices) => {
-                const smartDoor = devices
-                    .find((device) => device.deviceId === this.smartDoorDevice?.deviceId);
-                if(!smartDoor) return;
-
-                const accessory = this.ensureDoorAccessory(EXTERIOR_FRONT_DOOR_DEVICE);
-                if(!accessory) return;
-                this.updateSmartDoorState(accessory, smartDoor.op);
-            }, DeviceType.SMART_DOOR);
+        for(const doorDevice of EXTERIOR_DOOR_DEVICES) {
+            this.registerPushListener(doorDevice);
         }
 
+        this.addDeviceListener((devices) => {
+            if(devices.length > 1) {
+                this.log.warn("Currently, only one `smartdoor` device is supported. The other devices are discarded: %s", JSON.stringify(devices));
+            }
+            const device = devices[0];
+            for(const doorDevice of EXTERIOR_DOOR_DEVICES) {
+                if(!doorDevice.isSmartDoorLock) continue;
+
+                const accessory = this.addOrGetDoorAccessory(doorDevice);
+                if(!accessory) continue;
+
+                this.refreshSmartDoorLockState(accessory, device.op);
+            }
+        }, DeviceType.SMART_DOOR);
+
         setTimeout(() => {
-            this.ensureDoorAccessory(EXTERIOR_FRONT_DOOR_DEVICE);
-            this.ensureDoorAccessory(EXTERIOR_COMMUNAL_DOOR_DEVICE);
+            for(const doorDevice of EXTERIOR_DOOR_DEVICES) {
+                this.addOrGetDoorAccessory(doorDevice);
+            }
         }, 1000);
     }
 }

--- a/homebridge/accessories/smart-elife/door.ts
+++ b/homebridge/accessories/smart-elife/door.ts
@@ -15,6 +15,7 @@ interface DoorAccessoryInterface extends AccessoryInterface {
     motionTimer?: Timeout
     motionDetected: boolean
     isSmartDoorLock?: boolean
+    closed?: boolean
     batteryLevel?: number
 }
 
@@ -50,7 +51,7 @@ const LOW_BATTERY_THRESHOLD = 20;
 export default class DoorAccessories extends Accessories<DoorAccessoryInterface> {
 
     constructor(log: Logging, api: API, config: SmartELifeConfig) {
-        super(log, api, config, DeviceType.DOOR, [api.hap.Service.MotionSensor, api.hap.Service.Battery]);
+        super(log, api, config, DeviceType.DOOR, [api.hap.Service.MotionSensor, api.hap.Service.ContactSensor, api.hap.Service.Battery]);
     }
 
     protected async identify(accessory: PlatformAccessory): Promise<void> {
@@ -90,7 +91,21 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             return;
         }
 
-        // `LockMechanism` service is discarded.
+        // `LockMechanism` requires a writable `LockTargetState`,
+        // which cannot express the BLE-only (read-only from HomeKit's perspective) door lock.
+        // A `ContactSensor` is inherently read-only
+        // and still surfaces the open/close state under the Home app's security category.
+        const contact = this.getService(accessory, this.api.hap.Service.ContactSensor);
+        contact.setPrimaryService(true);
+        contact.getCharacteristic(this.api.hap.Characteristic.ContactSensorState)
+            .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
+                const context = this.getAccessoryInterface(accessory);
+                if(context.closed === undefined) {
+                    callback(HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+                    return;
+                }
+                callback(undefined, this.contactSensorState(context.closed));
+            });
 
         const battery = this.getService(accessory, this.api.hap.Service.Battery);
         battery.getCharacteristic(this.api.hap.Characteristic.BatteryLevel)
@@ -115,6 +130,12 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 callback(undefined, this.api.hap.Characteristic.ChargingState.NOT_CHARGEABLE);
             });
+    }
+
+    private contactSensorState(closed: boolean): CharacteristicValue {
+        return closed
+            ? this.api.hap.Characteristic.ContactSensorState.CONTACT_DETECTED
+            : this.api.hap.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED;
     }
 
     private lowBatteryState(batteryLevel: number): CharacteristicValue {
@@ -150,12 +171,27 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             motionTimer: context?.motionTimer,
             motionDetected: context?.motionDetected ?? false,
             isSmartDoorLock: doorDevice.isSmartDoorLock,
+            closed: doorDevice.isSmartDoorLock ? context?.closed : undefined,
             batteryLevel: doorDevice.isSmartDoorLock ? context?.batteryLevel : undefined,
         });
     }
 
     private refreshSmartDoorLockState(accessory: PlatformAccessory, op: any) {
         const context = this.getAccessoryInterface(accessory);
+
+        const status = op?.["status"];
+        if(status === "open") {
+            context.closed = false;
+        } else if(status === "close") {
+            context.closed = true;
+        } else {
+            this.log.debug("Ignoring unknown smartdoor status: %s", String(status));
+        }
+        if(context.closed !== undefined) {
+            accessory.getService(this.api.hap.Service.ContactSensor)
+                ?.getCharacteristic(this.api.hap.Characteristic.ContactSensorState)
+                .updateValue(this.contactSensorState(context.closed));
+        }
 
         const parsedBatteryLevel = this.parseBatteryLevel(op?.["battery"]);
         if(parsedBatteryLevel === undefined) return;
@@ -215,6 +251,9 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                 this.log.warn("Currently, only one `smartdoor` device is supported. The other devices are discarded: %s", JSON.stringify(devices));
             }
             const device = devices[0];
+            // The wallpad occasionally reports an empty op list, and smartdoor events from
+            // other households are filtered out by the config, leaving no devices here.
+            if(!device) return;
             for(const doorDevice of EXTERIOR_DOOR_DEVICES) {
                 if(!doorDevice.isSmartDoorLock) continue;
 

--- a/homebridge/accessories/smart-elife/door.ts
+++ b/homebridge/accessories/smart-elife/door.ts
@@ -251,9 +251,6 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                 this.log.warn("Currently, only one `smartdoor` device is supported. The other devices are discarded: %s", JSON.stringify(devices));
             }
             const device = devices[0];
-            // The wallpad occasionally reports an empty op list, and smartdoor events from
-            // other households are filtered out by the config, leaving no devices here.
-            if(!device) return;
             for(const doorDevice of EXTERIOR_DOOR_DEVICES) {
                 if(!doorDevice.isSmartDoorLock) continue;
 


### PR DESCRIPTION
# Summary

Smart eLife recently changed the payload format of its FCM pushes on the server side, which silently broke every push-driven accessory: vehicle in/out detection and door-access motion sensors stopped reacting even though the pushes were delivered to the plugin. This adapts the push parser to the new format and, now that the communal-door access push has finally been identified, revives the long-commented-out communal door device as a motion-only accessory.

# Root cause

`configurePushNotification()` in `core/smart-elife/smart-elife-client.ts` only understood the legacy payload, where `message.data.data` holds a JSON string whose `data1`/`data2`/`data3` fields are joined into the `PushType` key (e.g. `5-46`). The server now sends a single top-level code instead — e.g. `"data": {"data4": "58"}` with no `data` key — so the handler discarded every notification with `Unexpected Push message (no data)` and no push listener ever fired.

# Changes
- The push-type parser now understands both formats: the legacy `data1-data2-data3` JSON payload first, then the new top-level `data4` code (`58` = vehicle in/out, `64` = door access — both captured from a production Homebridge log), and finally a notification-title fallback (`입출차`/`출입`) so unseen codes in a known category (e.g. a possible separate code for vehicle exit) still route correctly.
- The door-access (`출입`) category covers both the household front door and the communal door, and only the notification body tells them apart. Bodies pointing at the communal door (`공동`) now resolve to a new `PushType.COMMUNAL_DOOR`; everything else stays on `FRONT_DOOR`.
- Revived `EXTERIOR_COMMUNAL_DOOR_DEVICE` (`CMFDOR002`), commented out in February 2026 because the communal-door push type had not been discovered yet, and registered it as a motion-only accessory driven by `COMMUNAL_DOOR` pushes. The communal entrance has no control channel (the server only reports access events, such as someone entering the communal entrance passcode), so a `MotionSensor` is the only faithful HomeKit mapping. `LockMechanism`/`Battery` services now attach exclusively to the front-door accessory, which mirrors the smart door lock.
- Rejected alternative: keeping all access pushes on the front-door sensor would have preserved the previous single-sensor behavior, but it permanently mislabels communal-entrance traffic. The body-based split was chosen because the body is the only field that distinguishes the two doors.
- The config UI wizard offers the communal door device again, and legacy JSON parsing is now guarded so a malformed payload logs a warning instead of throwing inside the notification handler.

# Migration

- **The communal door sensor does not appear automatically.** The runtime only registers devices present in `config.devices`, so existing users must re-run the configuration wizard (or manually add a `door` device with id `CMFDOR002`) to get the new sensor.
- **Door-access routing changes.** Access pushes whose body points at the communal door no longer fire the household front-door motion sensor. Until the communal door device is added to the config, those pushes are ignored with an `Unknown device: CMFDOR002` warning — users who relied on the front-door sensor reacting to communal-entrance access must add the new device.

# Known limitations (follow-up)

- The doorbell cameras — the household doorbell (`CMFCAM001`) and the communal doorbell (`CMFCAM002`) — ride the exact same push pipeline (`PushType.VISITOR`, legacy `5-32`) and are **still broken by the same format change**: the visitor push has not been observed in the new payload format yet, so its `data4` code remains unmapped and doorbell motion/snapshots do not fire. TODO: the first doorbell press after this change will surface in the log as an `Unexpected Push message (unknown payload)` warning; map its `data4` code (and, if it carries a stable title, a `TITLE_PUSH_TYPES` entry) in `DATA4_PUSH_TYPES` to restore both doorbells.
    - Tracked in #184

# Testing

- `npm run build` (type check) passes.
- Ran the compiled parser against 12 payload cases: the exact new-format payloads captured from a production Homebridge log (`data4: 58` vehicle entry, `data4: 64` communal access), a hypothetical front-door access body, unmapped codes falling back by title, legacy-format payloads, and malformed input — all routed as expected.
- Not yet verified against a live wallpad.
