### PR TITLE
Fix/load and modify config

### DIFF
--- a/homebridge-ui/providers/daelim.ts
+++ b/homebridge-ui/providers/daelim.ts
@@ -11,6 +11,9 @@ import {VEHICLE_DEVICE_ID, VEHICLE_DISPLAY_NAME} from "../../homebridge/accessor
 import {CAMERA_DEVICES} from "../../homebridge/accessories/daelim/camera";
 import {DeviceSubTypes, Errors, LoginSubTypes, SubTypes, Types} from "../../core/daelim/fields";
 
+const DEVICE_DISCOVERY_TIMEOUT_MILLISECONDS = 30 * 1000;
+const WALLPAD_AUTHORIZATION_TIMEOUT_MILLISECONDS = 180 * 1000;
+
 interface ClientAuthorization {
     certification: string,
     login: string
@@ -27,6 +30,17 @@ interface EnqueuedAccessory {
     uid: string
 }
 
+interface ActiveDiscovery {
+    promise: Promise<Device[]>,
+    resolve: (devices: Device[]) => void,
+    reject: (error: Error) => void,
+    allowPasscode: boolean,
+    completeEmitted: boolean,
+    waitingForPasscode: boolean,
+    settled: boolean,
+    timeout?: Timeout
+}
+
 export default class DaelimUiServer extends AbstractUiProvider {
 
     private region?: string = undefined;
@@ -35,16 +49,15 @@ export default class DaelimUiServer extends AbstractUiProvider {
     private password?: string = undefined;
     private uuid?: string = undefined;
     private enqueuedAccessories: { [key: string]: EnqueuedAccessory[] } = {};
-    private enqueuedDeviceTypes: string[] = [];
+    private readonly pendingAccessories = new Set<string>();
     private devices: Device[] = [];
 
     private handler?: NetworkHandler = undefined;
-    private isLoggedIn: boolean = false;
+    private activeDiscovery?: ActiveDiscovery = undefined;
     private devicesFetched: boolean = false;
     private readonly authorization: ClientAuthorization;
     private readonly address: ClientAddress;
     private readonly semaphore = new Semaphore();
-    private semaphoreTimeout?: Timeout;
 
     constructor(server: HomebridgePluginUiServer, log: LoggerBase) {
         super(server, log);
@@ -67,13 +80,14 @@ export default class DaelimUiServer extends AbstractUiProvider {
     }
 
     async onRequestDevices(p: any) {
-        if(this.devicesFetched && this.devices) {
-            this.server.pushEvent("devices-fetched", {
-                devices: this.devices,
-            });
-        } else {
-            await this.signIn(p);
-        }
+        const devices = this.devicesFetched
+            ? [...this.devices]
+            : await this.discoverDevices(p, false);
+
+        // Keep the event for the existing pane, but make the request itself carry the
+        // same terminal result. The request rejects if discovery cannot complete.
+        this.server.pushEvent("devices-fetched", { devices });
+        return { devices };
     }
 
     isDeviceSupportedIn(menuItems: MenuItem[], deviceMenuName: string): boolean {
@@ -126,6 +140,13 @@ export default class DaelimUiServer extends AbstractUiProvider {
     }
 
     async invalidate(_: any) {
+        if(this.activeDiscovery && !this.activeDiscovery.settled) {
+            this.failDiscovery(new Error("Daelim device discovery was invalidated."));
+        } else {
+            this.cleanupTransport(false);
+        }
+        this.activeDiscovery = undefined;
+
         this.authorization.certification = '00000000';
         this.authorization.login = '';
         this.address.complex = '';
@@ -135,48 +156,37 @@ export default class DaelimUiServer extends AbstractUiProvider {
         this.username = undefined;
         this.password = undefined;
         this.uuid = undefined;
-        this.isLoggedIn = false;
         this.devicesFetched = false;
         this.devices = [];
     }
 
     async signIn(p: any) {
-        const { region, complex, username, password } = p;
+        const discovery = this.discoverDevices(p, true);
 
-        this.log.info(`region = ${region}, complex = ${complex}, username: ${username}`);
-
-        this.region = region;
-        this.complex = complex;
-        this.username = username;
-        this.password = password;
-        this.uuid = Utils.generateUUID(username);
-        if(region && complex) {
-            // create semaphores and its expirations
-            this.semaphore.createSemaphore();
-            this.semaphoreTimeout = setTimeout(() => {
-                if(!this.semaphoreTimeout) {
-                    return;
-                }
-                this.semaphore.removeSemaphore(); // remove timed out semaphore
-
-                clearTimeout(this.semaphoreTimeout);
-                this.semaphoreTimeout = undefined;
-            }, 10 * 1000);
-
-            this.log.info('Starting service...');
-            await this.createService();
-        }
+        // Sign-in continues to report progress through its existing events. Device
+        // fetching joins this same promise and is the request that exposes its result.
+        void discovery.catch((error: Error) => {
+            this.log.warn(error.message);
+        });
     }
 
     async authorizePasscode(payload: any) {
         const { passcode } = payload;
+        if(!this.activeDiscovery || this.activeDiscovery.settled) {
+            throw new Error("There is no active Daelim authorization request.");
+        }
 
-        this.sendUnreliableRequest({
+        this.resetDiscoveryTimeout(DEVICE_DISCOVERY_TIMEOUT_MILLISECONDS);
+        if(!this.sendUnreliableRequest({
             dong: this.address.complex,
             ho: this.address.room,
             id: this.username,
             num: String(passcode),
-        }, Types.LOGIN, LoginSubTypes.WALL_PAD_REQUEST);
+        }, Types.LOGIN, LoginSubTypes.WALL_PAD_REQUEST)) {
+            const error = new Error("Could not send the Daelim wall-pad authorization request.");
+            this.failPreparation(error);
+            throw error;
+        }
     }
 
     private static getFriendlyName(displayName: string, deviceType: string): string {
@@ -195,6 +205,10 @@ export default class DaelimUiServer extends AbstractUiProvider {
         return `${displayName} ${suffix}`.trim();
     }
 
+    private static accessoryKey(deviceType: string, uid: string): string {
+        return `${deviceType}:${uid}`;
+    }
+
     private getAuthorizationPIN(): string {
         let pin: string;
         if(this.authorization.login.length !== 8) {
@@ -205,189 +219,389 @@ export default class DaelimUiServer extends AbstractUiProvider {
         return pin;
     }
 
-    sendUnreliableRequest(body: any, type: Types, subType: SubTypes) {
-        if(this.handler !== undefined) {
-            this.handler.sendUnreliableRequest(body, this.getAuthorizationPIN(), type, subType);
-        }
+    private sendUnreliableRequest(body: any, type: Types, subType: SubTypes): boolean {
+        return this.handler?.sendUnreliableRequest(body, this.getAuthorizationPIN(), type, subType) || false;
     }
 
-    registerResponseListener(type: Types, subType: SubTypes, callback: ResponseCallback) {
-        if(this.handler !== undefined) {
-            this.handler.registerResponseListener(type, subType, callback);
-        }
+    private registerResponseListener(type: Types, subType: SubTypes, callback: ResponseCallback) {
+        this.handler?.registerResponseListener(type, subType, callback);
     }
 
-    registerErrorListener(error: Errors, callback: ErrorCallback) {
-        if(this.handler !== undefined) {
-            this.handler.registerErrorListener(error, callback);
-        }
+    private registerErrorListener(error: Errors, callback: ErrorCallback) {
+        this.handler?.registerErrorListener(error, callback);
     }
 
-    sendCertificationRequest() {
-        this.sendUnreliableRequest({
+    private sendCertificationRequest(): boolean {
+        return this.sendUnreliableRequest({
             id: this.username,
             pw: this.password,
             UUID: this.uuid,
         }, Types.LOGIN, LoginSubTypes.CERTIFICATION_PIN_REQUEST);
     }
 
-    async createService() {
+    private discoverDevices(p: any, allowPasscode: boolean): Promise<Device[]> {
+        if(this.devicesFetched) {
+            return Promise.resolve([...this.devices]);
+        }
+        if(this.activeDiscovery && !this.activeDiscovery.settled) {
+            this.activeDiscovery.allowPasscode ||= allowPasscode;
+            return this.activeDiscovery.promise;
+        }
+        if(this.activeDiscovery?.settled) {
+            if(!allowPasscode) {
+                // A pane fetch that starts just after a terminal failure must observe
+                // that failure instead of opening a second MMF connection.
+                return this.activeDiscovery.promise;
+            }
+            // An explicit sign-in is a user-requested retry.
+            this.activeDiscovery = undefined;
+        }
+
+        const { region, complex, username, password } = p || {};
+        if(!region || !complex || !username || !password) {
+            return Promise.reject(new Error("Daelim credentials and complex information are required."));
+        }
+
+        this.log.info(`region = ${region}, complex = ${complex}, username: ${username}`);
+        this.region = region;
+        this.complex = complex;
+        this.username = username;
+        this.password = password;
+        this.uuid = Utils.generateUUID(username);
+        this.devicesFetched = false;
+        this.devices = [];
+        this.enqueuedAccessories = {};
+        this.pendingAccessories.clear();
+
+        let resolveDiscovery!: (devices: Device[]) => void;
+        let rejectDiscovery!: (error: Error) => void;
+        const promise = new Promise<Device[]>((resolve, reject) => {
+            resolveDiscovery = resolve;
+            rejectDiscovery = reject;
+        });
+        const discovery: ActiveDiscovery = {
+            promise,
+            resolve: resolveDiscovery,
+            reject: rejectDiscovery,
+            allowPasscode,
+            completeEmitted: false,
+            waitingForPasscode: false,
+            settled: false
+        };
+        this.activeDiscovery = discovery;
+
+        try {
+            this.semaphore.createSemaphore();
+            this.resetDiscoveryTimeout(DEVICE_DISCOVERY_TIMEOUT_MILLISECONDS);
+            this.log.info('Starting service...');
+            void this.createService(discovery).catch((error: unknown) => {
+                if(this.activeDiscovery === discovery) {
+                    this.failPreparation(this.asError(error));
+                }
+            });
+        } catch(error: unknown) {
+            this.failPreparation(this.asError(error));
+        }
+
+        return promise;
+    }
+
+    private resetDiscoveryTimeout(timeoutMilliseconds: number) {
+        const discovery = this.activeDiscovery;
+        if(!discovery || discovery.settled) {
+            return;
+        }
+        if(discovery.timeout) {
+            clearTimeout(discovery.timeout);
+        }
+        discovery.timeout = setTimeout(() => {
+            this.failPreparation(new Error("Daelim device discovery timed out."));
+        }, timeoutMilliseconds);
+    }
+
+    private completeDiscovery() {
+        const discovery = this.activeDiscovery;
+        if(!discovery || discovery.settled) {
+            return;
+        }
+
+        discovery.settled = true;
+        const devices = [...this.devices];
+        this.devicesFetched = true;
+        this.cleanupTransport(true, discovery);
+        discovery.resolve(devices);
+    }
+
+    private failDiscovery(error: Error, eventName?: string, eventData: any = {}) {
+        const discovery = this.activeDiscovery;
+        if(!discovery || discovery.settled) {
+            return;
+        }
+
+        discovery.settled = true;
+        this.cleanupTransport(false, discovery);
+        if(eventName) {
+            this.server.pushEvent(eventName, eventData);
+        }
+        discovery.reject(error);
+    }
+
+    private failPreparation(error: Error) {
+        this.failDiscovery(error, 'authorization-failed', {
+            reason: 'wallpad-preparation-fail'
+        });
+    }
+
+    private cleanupTransport(preserveDevices: boolean, discovery = this.activeDiscovery) {
+        if(discovery?.timeout) {
+            clearTimeout(discovery.timeout);
+            discovery.timeout = undefined;
+        }
+
+        const handler = this.handler;
+        this.handler = undefined;
+        if(handler) {
+            handler.onConnected = undefined;
+            handler.onDisconnected = undefined;
+            handler.disconnect();
+        }
+
+        this.enqueuedAccessories = {};
+        this.pendingAccessories.clear();
+        if(!preserveDevices) {
+            this.devicesFetched = false;
+            this.devices = [];
+        }
+
+        try {
+            this.semaphore.removeSemaphore();
+        } catch(error: unknown) {
+            this.log.warn(`Could not remove the Daelim semaphore: ${this.asError(error).message}`);
+        }
+    }
+
+    private asError(error: unknown): Error {
+        return error instanceof Error ? error : new Error(String(error));
+    }
+
+    private requestWallpadAuthorization(includeDeleteRequests: boolean) {
+        const discovery = this.activeDiscovery;
+        if(!discovery || discovery.settled) {
+            return;
+        }
+        if(discovery.waitingForPasscode) {
+            return;
+        }
+
+        let requestsSent = true;
+        if(includeDeleteRequests) {
+            requestsSent = this.sendUnreliableRequest({
+                id: this.username,
+                pw: this.password
+            }, Types.LOGIN, LoginSubTypes.DELETE_CERTIFICATION_REQUEST) && requestsSent;
+            requestsSent = this.sendUnreliableRequest({
+                id: this.username
+            }, Types.LOGIN, LoginSubTypes.APPROVAL_DELETE_REQUEST) && requestsSent;
+        }
+        requestsSent = this.sendUnreliableRequest({
+            dong: this.address.complex,
+            ho: this.address.room,
+            id: this.username,
+            auth: 2
+        }, Types.LOGIN, LoginSubTypes.APPROVAL_REQUEST) && requestsSent;
+        if(!requestsSent) {
+            this.failPreparation(new Error("Could not request Daelim wall-pad authorization."));
+            return;
+        }
+
+        if(discovery.allowPasscode) {
+            discovery.waitingForPasscode = true;
+            this.resetDiscoveryTimeout(WALLPAD_AUTHORIZATION_TIMEOUT_MILLISECONDS);
+            this.server.pushEvent('require-wallpad-passcode', {});
+        } else {
+            this.failDiscovery(
+                new Error("Daelim wall-pad reauthorization is required."),
+                'require-wallpad-passcode'
+            );
+        }
+    }
+
+    private async createService(discovery: ActiveDiscovery) {
         const complex = await Utils.findMatchedComplex(this.region || "", this.complex || "");
+        if(this.activeDiscovery !== discovery || discovery.settled) {
+            return;
+        }
         const menuItems = await Utils.fetchSupportedMenus(complex);
+        if(this.activeDiscovery !== discovery || discovery.settled) {
+            return;
+        }
+
         this.prepareDefaultDevices(menuItems);
         this.handler = new NetworkHandler(this.log, complex);
         this.handler.onConnected = () => {
-            if(!this.username || !this.password) {
-                this.log.error("Username and password is not valid");
+            if(this.activeDiscovery !== discovery || discovery.settled) {
+                return;
             }
-            this.sendCertificationRequest();
+            if(!this.username || !this.password) {
+                this.failDiscovery(
+                    new Error("Username and password are not valid."),
+                    'authorization-failed',
+                    { reason: 'invalid-authorization' }
+                );
+                return;
+            }
+            if(!this.sendCertificationRequest()) {
+                this.failPreparation(new Error("Could not send the Daelim certification request."));
+            }
         };
         this.handler.onDisconnected = () => {
+            if(this.activeDiscovery !== discovery || discovery.settled) {
+                return;
+            }
             this.log.info('Connection broken.');
+            this.failPreparation(new Error("The Daelim connection closed before device discovery completed."));
         };
 
-        // Start the service
-        this.handler.handle();
-
-        // Event Listeners
         this.registerResponseListener(Types.LOGIN, LoginSubTypes.CERTIFICATION_PIN_RESPONSE, (body) => {
+            if(this.activeDiscovery !== discovery || discovery.settled) {
+                return;
+            }
             this.authorization.certification = body['certpin'];
             this.address.complex = body['dong'];
             this.address.room = body['ho'];
 
-            this.sendUnreliableRequest({
+            if(!this.sendUnreliableRequest({
                 id: this.username,
                 pw: this.password,
                 certpin: this.authorization.certification
-            }, Types.LOGIN, LoginSubTypes.LOGIN_PIN_REQUEST);
+            }, Types.LOGIN, LoginSubTypes.LOGIN_PIN_REQUEST)) {
+                this.failPreparation(new Error("Could not send the Daelim login request."));
+            }
         });
-        this.registerResponseListener(Types.LOGIN, LoginSubTypes.LOGIN_PIN_RESPONSE, async (body) => {
+        this.registerResponseListener(Types.LOGIN, LoginSubTypes.LOGIN_PIN_RESPONSE, (body) => {
+            if(this.activeDiscovery !== discovery || discovery.settled) {
+                return;
+            }
             this.authorization.login = body['loginpin'];
-            this.sendUnreliableRequest({}, Types.LOGIN, LoginSubTypes.MENU_REQUEST);
-        })
-        this.registerResponseListener(Types.LOGIN, LoginSubTypes.WALL_PAD_RESPONSE, async (_) => {
-            this.sendCertificationRequest();
+            if(!this.sendUnreliableRequest({}, Types.LOGIN, LoginSubTypes.MENU_REQUEST)) {
+                this.failPreparation(new Error("Could not request the Daelim device menu."));
+            }
         });
-        this.registerResponseListener(Types.LOGIN, LoginSubTypes.MENU_RESPONSE, async (body) => {
-            this.isLoggedIn = true;
-            this.server.pushEvent('complete', { uuid: this.uuid });
+        this.registerResponseListener(Types.LOGIN, LoginSubTypes.WALL_PAD_RESPONSE, () => {
+            if(this.activeDiscovery !== discovery || discovery.settled) {
+                return;
+            }
+            discovery.waitingForPasscode = false;
+            if(!this.sendCertificationRequest()) {
+                this.failPreparation(new Error("Could not restart Daelim certification."));
+            }
+        });
+        this.registerResponseListener(Types.LOGIN, LoginSubTypes.MENU_RESPONSE, (body) => {
+            if(this.activeDiscovery !== discovery || discovery.settled) {
+                return;
+            }
 
-            const controlInfo = body['controlinfo'];
-            const keys = Object.keys(controlInfo);
-            for(const key of keys) {
+            if(!discovery.completeEmitted) {
+                discovery.completeEmitted = true;
+                this.server.pushEvent('complete', { uuid: this.uuid });
+            }
+            this.resetDiscoveryTimeout(DEVICE_DISCOVERY_TIMEOUT_MILLISECONDS);
+
+            const controlInfo = body['controlinfo'] || {};
+            for(const key of Object.keys(controlInfo)) {
                 if(key === 'fan' && !this.isDeviceSupportedIn(menuItems, "환기")) {
                     // possibility of fan support in contents info but not in menu items
                     continue;
                 }
-                const devices = controlInfo[key]
-                if(devices && devices.length && !this.enqueuedAccessories[key]) {
-                    this.enqueuedAccessories[key] = [];
+
+                const devices = Array.isArray(controlInfo[key]) ? controlInfo[key] : [];
+                if(devices.length === 0) {
+                    continue;
                 }
+                this.enqueuedAccessories[key] = [];
                 for(const device of devices) {
-                    this.enqueuedAccessories[key].push({
+                    if(!device || device['uid'] === undefined) {
+                        this.failPreparation(new Error(`Invalid Daelim device metadata for ${key}.`));
+                        return;
+                    }
+                    const accessory = {
                         name: device['uname'],
                         deviceType: key,
-                        uid: device['uid']
-                    });
+                        uid: String(device['uid'])
+                    };
+                    this.enqueuedAccessories[key].push(accessory);
+                    this.pendingAccessories.add(DaelimUiServer.accessoryKey(key, accessory.uid));
                 }
-                this.enqueuedDeviceTypes.push(key);
-                this.sendUnreliableRequest({
+
+                if(!this.sendUnreliableRequest({
                     type: 'query',
                     item: [{
                         device: key,
                         uid: 'all'
                     }]
-                }, Types.DEVICE, DeviceSubTypes.QUERY_REQUEST);
+                }, Types.DEVICE, DeviceSubTypes.QUERY_REQUEST)) {
+                    this.failPreparation(new Error(`Could not query Daelim ${key} devices.`));
+                    return;
+                }
+            }
+
+            if(this.pendingAccessories.size === 0) {
+                this.completeDiscovery();
             }
         });
-        this.registerResponseListener(Types.DEVICE, DeviceSubTypes.QUERY_RESPONSE, async (body) => {
-            const items = body['item'] || [];
-            const filtered: EnqueuedAccessory[] = items.map((item: any) => {
-                const devices = this.enqueuedAccessories[item['device']];
-                for(const device of devices) {
-                    if(device.uid === item['uid']) {
-                        return device;
-                    }
-                }
-                return undefined;
-            }).filter((device: EnqueuedAccessory) => device !== undefined);
-
-            if(!filtered || !filtered.length) {
+        this.registerResponseListener(Types.DEVICE, DeviceSubTypes.QUERY_RESPONSE, (body) => {
+            if(this.activeDiscovery !== discovery || discovery.settled) {
                 return;
             }
-            for(const enqueuedAccessory of filtered) {
-                const deviceType = enqueuedAccessory.deviceType;
+
+            const items = Array.isArray(body['item']) ? body['item'] : [];
+            for(const item of items) {
+                const deviceType = item['device'];
+                const uid = String(item['uid']);
+                const enqueuedAccessory = (this.enqueuedAccessories[deviceType] || [])
+                    .find(device => device.uid === uid);
+                if(!enqueuedAccessory) {
+                    continue;
+                }
+
+                const key = DaelimUiServer.accessoryKey(deviceType, uid);
+                if(!this.pendingAccessories.delete(key)) {
+                    continue;
+                }
                 this.devices.push({
                     displayName: DaelimUiServer.getFriendlyName(enqueuedAccessory.name, deviceType),
                     name: enqueuedAccessory.name,
-                    deviceType: deviceType,
-                    deviceId: enqueuedAccessory.uid,
+                    deviceType,
+                    deviceId: uid,
                     disabled: false
-                })
-                const index = this.enqueuedAccessories[deviceType].indexOf(enqueuedAccessory);
-                if(index !== -1) {
-                    this.enqueuedAccessories[deviceType].splice(index, 1);
-                }
-                const typeIndex = this.enqueuedDeviceTypes.indexOf(deviceType);
-                if(typeIndex !== -1) {
-                    this.enqueuedDeviceTypes.splice(typeIndex, 1);
-                }
-            }
-            if(this.enqueuedDeviceTypes.length === 0) {
-                // disconnect all
-                if(this.handler) {
-                    this.handler.disconnect();
-                    this.handler = undefined;
-                }
-
-                this.server.pushEvent('devices-fetched', {
-                    devices: this.devices,
                 });
-                this.devicesFetched = true;
+            }
 
-                await this.invalidate(null);
-
-                // remove all semaphores
-                this.semaphore.removeSemaphore();
-                clearTimeout(this.semaphoreTimeout);
-                this.semaphoreTimeout = undefined;
+            if(this.pendingAccessories.size === 0) {
+                this.completeDiscovery();
             }
         });
-        // Error Listeners
-        this.registerErrorListener(Errors.UNCERTIFIED_DEVICE, () => {
-            this.sendUnreliableRequest({
-                id: this.username,
-                pw: this.password
-            }, Types.LOGIN, LoginSubTypes.DELETE_CERTIFICATION_REQUEST);
-            this.sendUnreliableRequest({
-                id: this.username
-            }, Types.LOGIN, LoginSubTypes.APPROVAL_DELETE_REQUEST);
-            this.sendUnreliableRequest({
-                dong: this.address.complex,
-                ho: this.address.room,
-                id: this.username,
-                auth: 2
-            }, Types.LOGIN, LoginSubTypes.APPROVAL_REQUEST);
 
-            this.server.pushEvent('require-wallpad-passcode', {});
+        this.registerErrorListener(Errors.UNCERTIFIED_DEVICE, () => {
+            this.requestWallpadAuthorization(true);
         });
         this.registerErrorListener(Errors.INVALID_CERTIFICATION_NUMBER, () => {
-            this.server.pushEvent('invalid-wallpad-passcode', {});
+            this.failDiscovery(
+                new Error("The Daelim wall-pad passcode is invalid."),
+                'invalid-wallpad-passcode'
+            );
         });
         this.registerErrorListener(Errors.INVALID_USERNAME_AND_PASSWORD, () => {
-            this.server.pushEvent('authorization-failed', {
-                reason: 'invalid-authorization'
-            });
+            this.failDiscovery(
+                new Error("The Daelim username or password is invalid."),
+                'authorization-failed',
+                { reason: 'invalid-authorization' }
+            );
         });
         this.registerErrorListener(Errors.REGISTRATION_NOT_COMPLETED, () => {
-            this.sendUnreliableRequest({
-                dong: this.address.complex,
-                ho: this.address.room,
-                id: this.username,
-                auth: 2
-            }, Types.LOGIN, LoginSubTypes.APPROVAL_REQUEST);
-
-            this.server.pushEvent('require-wallpad-passcode', {});
+            this.requestWallpadAuthorization(false);
         });
+
+        this.handler.handle();
     }
 }

--- a/homebridge-ui/providers/smart-elife.ts
+++ b/homebridge-ui/providers/smart-elife.ts
@@ -136,6 +136,10 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
         this.devicesFetched = true;
 
         // On success
+        // `devices-fetched` is pushed before `complete`,
+        // so that a pane waiting only for the device list settles before the wizard moves on.
+        // Without it, a sign-in triggered by `/fetch-devices` would report nothing the caller listens for.
+        this.server.pushEvent("devices-fetched", { devices });
         this.server.pushEvent("complete", { uuid, roomKey, userKey, version });
     }
 

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -716,9 +716,26 @@ class WallpadPasscodePane extends Pane {
     }
 }
 
+// Backstop for the device refresh.
+// The smart-elife request settles on its own because its handler awaits the whole sign-in,
+// but daelim only acknowledges the request and keeps streaming devices in afterwards,
+// so a stalled wall-pad would otherwise leave the advanced button locked forever.
+const DEVICE_REFRESH_TIMEOUT_MILLISECONDS = 30 * 1000;
+const DEVICE_REFRESH_FAILED_MESSAGE = "기기 목록을 갱신하지 못했습니다. 저장된 목록으로 설정을 편집합니다.";
+const WALLPAD_REAUTHORIZATION_MESSAGE = "월패드 재인증이 필요합니다. 기기 목록을 갱신하려면 '재설정'으로 다시 로그인해주세요.";
+
 class CompletePane extends Pane {
     constructor(element, config) {
         super(element, config);
+
+        // The refresh is not a single promise:
+        // the request and its result arrive through different channels,
+        // and some failure paths emit nothing at all.
+        // The advanced button opens once the refresh has settled either way.
+        this._settled = false;
+        this._settleTimeout = undefined;
+        this._refreshed = false;
+        this._advancedFormOpened = false;
 
         this.pane = document.createElement("div");
         this.pane.classList.add("hidden");
@@ -750,6 +767,21 @@ class CompletePane extends Pane {
         return new ResetConfirmablePane(this.element, this.config);
     }
 
+    _settle(warning) {
+        if(this._settled) {
+            return; // only the first terminal state wins
+        }
+        this._settled = true;
+        if(this._settleTimeout) {
+            clearTimeout(this._settleTimeout);
+            this._settleTimeout = undefined;
+        }
+        this.advancedButton.removeAttribute("disabled");
+        if(warning) {
+            window.homebridge.toast.warning(warning);
+        }
+    }
+
     devicesEquals(oldDevice, newDevice) {
         if(this.config.provider === "daelim") {
             return oldDevice.name === newDevice.name
@@ -766,16 +798,44 @@ class CompletePane extends Pane {
         this.ensureAttached();
         refreshTrademark(this.config);
         setTimeout(async () => {
-            await window.homebridge.request(`/${this.config.provider}/fetch-devices`, {
-                region: this.config.region,
-                complex: this.config.complex,
-                username: this.config.username,
-                password: this.config.password,
-            });
+            try {
+                await window.homebridge.request(`/${this.config.provider}/fetch-devices`, {
+                    region: this.config.region,
+                    complex: this.config.complex,
+                    username: this.config.username,
+                    password: this.config.password,
+                });
+                if(this.config.provider === "smart-elife" && !this._refreshed) {
+                    // The handler awaits the whole sign-in,
+                    // so returning without having reported any device means the query gave up quietly.
+                    this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
+                }
+            } catch(error) {
+                console.error("Could not refresh the device list:", error);
+                this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
+            }
         }, 0);
+        this._settleTimeout = setTimeout(() => {
+            this._settleTimeout = undefined;
+            this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
+        }, DEVICE_REFRESH_TIMEOUT_MILLISECONDS);
+        this.addHomebridgeListener("authorization-failed", () => {
+            this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
+        });
+        this.addHomebridgeListener("require-wallpad-passcode", () => {
+            this._settle(WALLPAD_REAUTHORIZATION_MESSAGE);
+        });
         this.addHomebridgeListener("devices-fetched", async (event) => {
             const devices = event["data"].devices;
             console.log(`Num of devices: ${devices.length}`);
+
+            this._refreshed = true; // mark before yielding, the request may settle next
+            if(this._advancedFormOpened) {
+                // The user is already editing the device list,
+                // and the button can only have been opened by an earlier `_settle()`.
+                // Replacing the list now would silently discard those edits.
+                return;
+            }
 
             const availableDevices = [];
             for(const device of devices) {
@@ -791,7 +851,7 @@ class CompletePane extends Pane {
             await this.updatePluginConfig();
             await this.savePluginConfig();
 
-            this.advancedButton.removeAttribute("disabled");
+            this._settle();
         });
         this.addListener(this.resetButton, "click", async () => {
             await this.advance({}, this.nextPane());
@@ -803,6 +863,8 @@ class CompletePane extends Pane {
         });
 
         this.addListener(this.advancedButton, "click", async () => {
+            this._advancedFormOpened = true;
+
             document.getElementById("setupForm").classList.add("hidden");
             document.getElementById("footer").classList.add("hidden");
             document.getElementById("advancedForm").classList.remove("hidden");
@@ -816,6 +878,14 @@ class CompletePane extends Pane {
                 this.updatePluginConfig();
             });
         });
+    }
+
+    dispose() {
+        if(this._settleTimeout) {
+            clearTimeout(this._settleTimeout);
+            this._settleTimeout = undefined;
+        }
+        super.dispose();
     }
 }
 

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -716,11 +716,6 @@ class WallpadPasscodePane extends Pane {
     }
 }
 
-// Backstop for the device refresh.
-// The smart-elife request settles on its own because its handler awaits the whole sign-in,
-// but daelim only acknowledges the request and keeps streaming devices in afterwards,
-// so a stalled wall-pad would otherwise leave the advanced button locked forever.
-const DEVICE_REFRESH_TIMEOUT_MILLISECONDS = 30 * 1000;
 const DEVICE_REFRESH_FAILED_MESSAGE = "기기 목록을 갱신하지 못했습니다. 저장된 목록으로 설정을 편집합니다.";
 const WALLPAD_REAUTHORIZATION_MESSAGE = "월패드 재인증이 필요합니다. 기기 목록을 갱신하려면 '재설정'으로 다시 로그인해주세요.";
 
@@ -728,12 +723,9 @@ class CompletePane extends Pane {
     constructor(element, config) {
         super(element, config);
 
-        // The refresh is not a single promise:
-        // the request and its result arrive through different channels,
-        // and some failure paths emit nothing at all.
-        // The advanced button opens once the refresh has settled either way.
+        // Device data still arrives through an event for compatibility, while each
+        // provider request now has its own terminal success or failure.
         this._settled = false;
-        this._settleTimeout = undefined;
         this._refreshed = false;
         this._advancedFormOpened = false;
 
@@ -772,10 +764,6 @@ class CompletePane extends Pane {
             return; // only the first terminal state wins
         }
         this._settled = true;
-        if(this._settleTimeout) {
-            clearTimeout(this._settleTimeout);
-            this._settleTimeout = undefined;
-        }
         this.advancedButton.removeAttribute("disabled");
         if(warning) {
             window.homebridge.toast.warning(warning);
@@ -815,10 +803,6 @@ class CompletePane extends Pane {
                 this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
             }
         }, 0);
-        this._settleTimeout = setTimeout(() => {
-            this._settleTimeout = undefined;
-            this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
-        }, DEVICE_REFRESH_TIMEOUT_MILLISECONDS);
         this.addHomebridgeListener("authorization-failed", () => {
             this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
         });
@@ -880,13 +864,6 @@ class CompletePane extends Pane {
         });
     }
 
-    dispose() {
-        if(this._settleTimeout) {
-            clearTimeout(this._settleTimeout);
-            this._settleTimeout = undefined;
-        }
-        super.dispose();
-    }
 }
 
 class ResetConfirmablePane extends Pane {

--- a/homebridge/providers/daelim.ts
+++ b/homebridge/providers/daelim.ts
@@ -17,6 +17,11 @@ import {VehicleAccessories} from "../accessories/daelim/vehicle";
 import {CameraAccessories} from "../accessories/daelim/camera";
 import PushReceiverStateStore from "../../core/push-receiver-state-store";
 
+// Keys without which the plugin cannot sign in at all.
+// Every other key either has a fallback (`devices`) or is unrelated,
+// and must not invalidate the config.
+const REQUIRED_CONFIG_KEYS = ["region", "complex", "username", "password", "uuid"];
+
 export default class DaelimProvider extends AbstractProvider {
 
     private client?: DaelimClient;
@@ -42,11 +47,10 @@ export default class DaelimProvider extends AbstractProvider {
     }
 
     configureCredentials(config: PlatformConfig): DaelimConfig | undefined {
-        for(const key in config) {
-            const value = config[key];
-            if(value === undefined || !value) {
-                return undefined;
-            }
+        const missingKeys = REQUIRED_CONFIG_KEYS.filter(key => !config[key]);
+        if(missingKeys.length > 0) {
+            this.log.warn(`The plugin configuration is missing required values: ${missingKeys.join(", ")}`);
+            return undefined;
         }
         return {
             region: config["region"],

--- a/homebridge/providers/smart-elife.ts
+++ b/homebridge/providers/smart-elife.ts
@@ -20,6 +20,11 @@ import DoorAccessories from "../accessories/smart-elife/door";
 import VehicleAccessories from "../accessories/smart-elife/vehicle";
 import CameraAccessories from "../accessories/smart-elife/camera";
 
+// Keys without which the plugin cannot sign in at all.
+// Every other key is either optional (`roomKey`, `userKey`) or has a fallback,
+// and must not invalidate the config.
+const REQUIRED_CONFIG_KEYS = ["username", "password", "uuid"];
+
 export default class SmartELifeProvider extends AbstractProvider {
 
     private readonly config?: SmartELifeConfig;
@@ -45,11 +50,10 @@ export default class SmartELifeProvider extends AbstractProvider {
     }
 
     loadConfig(config: PlatformConfig): SmartELifeConfig | undefined {
-        for(const key in config) {
-            const value = config[key];
-            if(value === undefined || !value) {
-                return undefined;
-            }
+        const missingKeys = REQUIRED_CONFIG_KEYS.filter(key => !config[key]);
+        if(missingKeys.length > 0) {
+            this.log.warn(`The plugin configuration is missing required values: ${missingKeys.join(", ")}`);
+            return undefined;
         }
         return {
             username: config["username"],


### PR DESCRIPTION
# Summary

Two defects made the plugin's configuration unusable from both ends: any falsy value in `config.json` caused both providers to discard the entire configuration and register no accessories, and the Smart eLife settings UI could never unlock its `고급` (advanced) editor once the plugin had been set up, so the device list could not be edited at all.

They compound — the `고급` (advanced) editor is what writes the top-level values the loader then rejects — so they are fixed together, loader first.

# Root cause

**Configuration loading.** `SmartELifeProvider.loadConfig()` and `DaelimProvider.configureCredentials()` validated by walking every top-level key of `PlatformConfig` and returning `undefined` if any value was falsy. Returning `undefined` skips accessory construction in the constructor and leaves `serve()` logging "The plugin hasn't been configured", so every accessory in the Home app goes unresponsive. An empty `roomKey` or `userKey` — both declared optional and given a `|| ""` fallback in the client — was enough to trigger it. The same walk also meant no boolean option could ever be added to the schema: the settings form writes an unchecked checkbox as `false`, so opening the settings page and saving would kill the plugin.

**`고급` (advanced) editor.** `CompletePane` renders the `고급` (advanced) button `disabled` and only enables it from its `devices-fetched` handler. Reopening the settings of an already configured plugin passes straight through to `CompletePane`, which issues one `/fetch-devices`; the custom UI server has not signed in yet, so `onRequestDevices()` falls through to `signIn()`. For Smart eLife that path pushes `complete` and never `devices-fetched` — the only place it pushed that event was the cached branch, which requires a sign-in to have already happened — so the button stayed disabled permanently. daelim was unaffected, because its sign-in reports `devices-fetched` once its device queries drain. Failure was worse than silent: `CompletePane` listened for no failure event at all, and both `signIn()`'s `default:` branch and a throwing `fetchDevices()` emit nothing.

# Changes

- Validate an explicit required-key list instead of every key — `username`, `password`, `uuid` for Smart eLife, plus `region` and `complex` for daelim — and log which keys are missing. `uuid` is already re-checked by `serve()`; `roomKey` and `userKey` are optional; `devices` has a `|| []` fallback.
- Apply the same fix to `DaelimProvider.configureCredentials()`, which carried a byte-identical walk. It cannot trigger today, since daelim has no nullable or boolean top-level key, but it has the same latent constraint.
- Push `devices-fetched` from the Smart eLife sign-in success path, before `complete`, so a caller waiting only for the device list is answered.
- Gate the `고급` (advanced) button on the refresh having *settled* rather than succeeded. `_settle()` is idempotent and is reached from five terminal states: the device list arriving, `authorization-failed`, `require-wallpad-passcode`, the request promise rejecting, and a 30s backstop. Only daelim really needs the backstop — its handler acknowledges the request and keeps streaming devices in afterwards — but it is kept for both as a last line of defence. Opening the button immediately from the saved device list was considered and rejected: waiting a few seconds to show a freshly fetched list is the better trade.
- Warn through a toast whenever the button opens on a failed refresh, naming wall-pad re-authorization separately since that one is actionable.
- Skip the merge when the `고급` (advanced) form is already open, so a late device list cannot silently revert edits in progress. `_refreshed` is set before the handler yields, so the request promise settling next does not raise a false failure warning.
- Clear the backstop in `dispose()`, so it cannot fire against a detached pane.

# Testing

`npm run build` and `tsc --noEmit` clean.

`loadConfig()` and `configureCredentials()` were driven directly from the built `dist` across config variants. Both now accept an unchecked boolean option, empty `roomKey`/`userKey`, and an empty `devices` array, and both still reject a missing `password` or an unconfigured platform, naming the missing keys.

`pane.js` is not compiled, so `CompletePane` was driven in Node against a stubbed DOM and `window.homebridge` across nine scenarios: success, the silent `default:` branch, a rejecting request, `authorization-failed`, `require-wallpad-passcode`, the daelim timeout, daelim's normal acknowledge-then-event flow, a late device list arriving while the `고급` (advanced) form is open, and timer cleanup on `dispose()`. Notably the success path raises no false failure warning, and a late list does not revert an edit in progress.

Verified on a live Raspberry Pi install: hb-service, Homebridge UI v5.27.0, Smart eLife provider, plugin running as a child bridge. Reopening the plugin settings now unlocks the `고급` (advanced) button about a second after the request — the log shows `/smart-elife/fetch-devices`, the full sign-in, and the `devices-fetched` handler saving `config.json`, none of which could happen before. A previously disabled outlet was re-enabled from the `고급` (advanced) form and appeared in the Home app after a child bridge restart, then disabled again and removed; both directions are in the log.

Not tested: the daelim provider against real hardware — there is no test account for it. Its changes are the required-key list and the shared `CompletePane` code, both covered in Node only.