### PR TITLE
Report a disabled device once instead of on every poll

### DIFF
--- a/homebridge/accessories/daelim/accessories.ts
+++ b/homebridge/accessories/daelim/accessories.ts
@@ -34,6 +34,10 @@ export class Accessories<T extends AccessoryInterface> {
 
     protected readonly accessories: PlatformAccessory[] = [];
     protected readonly enqueuedAccessoriesCache: EnqueuedAccessoryMap = {};
+    // Device IDs already reported as disabled.
+    // `addAccessory()` can run repeatedly as device state is polled, so the notice
+    // has to be remembered or it repeats for the lifetime of the process.
+    private readonly reportedDisabledDevices = new Set<string>();
 
     private lastInitRequestTimestamp: number = -1;
     protected removeLegacyService = false;
@@ -199,7 +203,10 @@ export class Accessories<T extends AccessoryInterface> {
                 if(deviceInfo && deviceInfo.disabled) {
                     // unregister the accessory since the accessory is cached in homebridge
                     this.api.unregisterPlatformAccessories(Utils.PLUGIN_NAME, Utils.PLATFORM_NAME, [ cachedAccessory ]);
-                    this.log.debug('The device (%s, uid:%s) is disabled in config, therefore unregistered immediately', deviceInfo.name, deviceInfo.deviceId);
+                    if(!this.reportedDisabledDevices.has(context.deviceID)) {
+                        this.reportedDisabledDevices.add(context.deviceID);
+                        this.log.info('The device (%s, uid:%s) is disabled in config, therefore unregistered immediately', deviceInfo.name, deviceInfo.deviceId);
+                    }
                     return undefined;
                 }
                 const version = cachedAccessory.context.version;
@@ -231,7 +238,10 @@ export class Accessories<T extends AccessoryInterface> {
             }
         }
         if(deviceInfo && deviceInfo.disabled) {
-            this.log.debug('The device (%s, uid:%s) is disabled in config', deviceInfo.name, deviceInfo.deviceId);
+            if(!this.reportedDisabledDevices.has(context.deviceID)) {
+                this.reportedDisabledDevices.add(context.deviceID);
+                this.log.info('The device (%s, uid:%s) is disabled in config', deviceInfo.name, deviceInfo.deviceId);
+            }
             return undefined;
         }
         const seed = NEW_UUID_COMBINATION(context);

--- a/homebridge/accessories/smart-elife/accessories.ts
+++ b/homebridge/accessories/smart-elife/accessories.ts
@@ -25,6 +25,10 @@ export default class Accessories<T extends AccessoryInterface> {
     protected deferredTasks: Record<string, Promise<boolean>> = {};
     protected readonly accessories: PlatformAccessory[] = [];
     protected readonly capabilities: WallPadCapabilities;
+    // Device IDs already reported as disabled.
+    // `addOrGetAccessory()` runs on every device poll, not just at registration,
+    // so the notice has to be remembered or it repeats for the lifetime of the process.
+    private readonly reportedDisabledDevices = new Set<string>();
 
     constructor(protected readonly log: Logging,
                 protected readonly api: API,
@@ -54,7 +58,10 @@ export default class Accessories<T extends AccessoryInterface> {
         const device = this.findDevice(context.deviceId);
         const cachedAccessory = this.findAccessory(context.deviceId);
         if(device && device.disabled) {
-            this.log.info("The device (%s) is disabled.", device.displayName);
+            if(!this.reportedDisabledDevices.has(context.deviceId)) {
+                this.reportedDisabledDevices.add(context.deviceId);
+                this.log.info("The device (%s) is disabled.", device.displayName);
+            }
 
             // Unregister accessory if exists.
             if(cachedAccessory)


### PR DESCRIPTION
# Summary

The Smart eLife provider logged `The device (...) is disabled.` on every device poll rather than once at registration, so a home with disabled accessories accumulated the same lines every 30 seconds — roughly a quarter of the whole log file. This implements the approach chosen in #186: keep the notice at `info` so it still explains why a device is missing from the Home app, but emit it only the first time per device.

# Root cause

`Accessories.addOrGetAccessory()` emitted the notice unconditionally, and it is called from every device listener on every poll rather than only when accessories are first registered. With `POLLING_INTERVAL_MILLISECONDS` at 30 seconds, a home with 12 disabled devices produced roughly 1,560 lines an hour.

The daelim provider never had the problem because it reports the same condition at `debug`, so the two providers were logging identical situations at different levels.

# Changes

- Remember which device IDs have already been reported, per `Accessories` instance, and skip the notice after the first one. The level stays `info`, so the startup notice is unchanged; only the repetition is gone. Lowering it to `debug` to match daelim was the other candidate, but it would have hidden the notice from anyone diagnosing a missing accessory.
- The set is keyed by device ID alone. That is safe because one `Accessories` instance exists per device type and `findDevice()` filters by that type, so IDs cannot collide within an instance.
- Nothing is removed from the set when a device is enabled. `config.devices` is read once in the provider constructor, so a device cannot change state within the lifetime of a process; re-enabling one needs a (child) bridge restart, which builds fresh instances anyway. A removal branch would be unreachable code.

# Testing

`npm run build` and `tsc --noEmit` clean.

Verified on a live Raspberry Pi install: hb-service, Homebridge 2.2.1 with Homebridge UI v5.27.0, Smart eLife provider running as a child bridge, 12 disabled outlets.

| Window | Lines | Shape |
|---|---|---|
| 1 minute before the build | 34 | 17 lines every 30s |
| startup, after the build | 12 | one line per disabled device |
| the following 8 poll cycles | 0 | silent |

Every one of the 12 disabled devices was named exactly once at startup, none missing and none repeated, which also confirms the set is keyed correctly per instance.

Not tested: the daelim provider — it is untouched by this change and has no test account available.