### PR TITLE
Fix visitor image routing

### DIFF
--- a/core/interfaces/smart-elife-config.ts
+++ b/core/interfaces/smart-elife-config.ts
@@ -98,6 +98,7 @@ export enum PushType {
 export const DATA4_PUSH_TYPES: { [code: string]: PushType } = {
     "55": PushType.FRONT_DOOR, // 도어락: "수동에 의하여 문이 열렸습니다." (sent only when push_doorlock is enabled)
     "58": PushType.CAR, // 입출차: "등록 ... 차량이 입차하였습니다."
+    "63": PushType.VISITOR, // 출입: "방문자 이미지가 저장되었습니다." (interphone camera snapshot)
     "64": PushType.FRONT_DOOR, // 출입: "공동 현관 출입이 감지되었습니다." (refined by body into COMMUNAL_DOOR)
 };
 

--- a/core/interfaces/smart-elife-config.ts
+++ b/core/interfaces/smart-elife-config.ts
@@ -98,7 +98,7 @@ export enum PushType {
 export const DATA4_PUSH_TYPES: { [code: string]: PushType } = {
     "55": PushType.FRONT_DOOR, // 도어락: "수동에 의하여 문이 열렸습니다." (sent only when push_doorlock is enabled)
     "58": PushType.CAR, // 입출차: "등록 ... 차량이 입차하였습니다."
-    "63": PushType.VISITOR, // 출입: "방문자 이미지가 저장되었습니다." (interphone camera snapshot)
+    "63": PushType.VISITOR, // 출입: "방문자 이미지가 저장되었습니다." (doorbell camera snapshot)
     "64": PushType.FRONT_DOOR, // 출입: "공동 현관 출입이 감지되었습니다." (refined by body into COMMUNAL_DOOR)
 };
 

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -597,10 +597,19 @@ export default class SmartELifeClient {
 
     private parsePushType(data: { [key: string]: unknown } | undefined, title?: string, body?: string): PushType {
         const pushType = this.parseRawPushType(data, title);
-        // The access (출입) push category covers both the household front door and
-        // the communal door; only the notification body tells them apart.
-        if(pushType === PushType.FRONT_DOOR && !!body && body.includes("공동")) {
-            return PushType.COMMUNAL_DOOR;
+        // The access (출입) push category covers the household front door, the communal
+        // door and the interphone camera alike; only the notification body tells them
+        // apart. Without this an unmapped `data4` falls back to the title and every one
+        // of them would resolve to FRONT_DOOR.
+        if(pushType === PushType.FRONT_DOOR && !!body) {
+            // A visitor snapshot is not tied to either door - the camera accessory reads
+            // `door_type` off the visitor board to decide which one it belongs to.
+            if(body.includes("방문자")) {
+                return PushType.VISITOR;
+            }
+            if(body.includes("공동")) {
+                return PushType.COMMUNAL_DOOR;
+            }
         }
         return pushType;
     }

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -601,7 +601,7 @@ export default class SmartELifeClient {
     private parsePushType(data: { [key: string]: unknown } | undefined, title?: string, body?: string): PushType {
         const pushType = this.parseRawPushType(data, title);
         // The access (출입) push category covers the household front door,
-        // the communal door and the interphone camera alike;
+        // the communal door and the doorbell camera alike;
         // only the notification body tells them apart.
         // Without this an unmapped `data4` falls back to the title,
         // and every one of them would resolve to FRONT_DOOR.

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -36,7 +36,10 @@ export interface ListenerMetadata {
 }
 
 export type Listener = (data: any | undefined, error: ListenerError, metadata?: ListenerMetadata) => void;
-export type PushListener = (title: string | undefined, message: string | undefined) => void;
+// A listener may run asynchronously - the camera one fetches the visitor snapshot
+// over the network - so the return type has to admit a promise
+// for the dispatcher to be able to catch its rejection.
+export type PushListener = (title: string | undefined, message: string | undefined) => void | Promise<void>;
 
 interface ListenerInfo {
     deviceType: DeviceType
@@ -653,6 +656,25 @@ export default class SmartELifeClient {
         return PushType.UNKNOWN;
     }
 
+    // A rejected listener would otherwise reach the process as an unhandled rejection,
+    // which terminates the bridge on current Node versions.
+    // Nothing upstream can act on the failure anyway,
+    // so it is contained here and only reported.
+    private dispatchPushListener(info: PushListenerInfo, title?: string, body?: string) {
+        try {
+            void Promise.resolve(info.listener(title, body)).catch((e) => {
+                this.reportPushListenerFailure(info.pushType, e);
+            });
+        } catch(e) {
+            this.reportPushListenerFailure(info.pushType, e);
+        }
+    }
+
+    private reportPushListenerFailure(pushType: PushType, e: unknown) {
+        this.log.error("Push listener for %s failed: %s", pushType.toString(), (e as Error)?.message || e);
+        this.log.debug("Push listener failure: %s", (e as Error)?.stack || "no stack available");
+    }
+
     private async configurePushNotification() {
         if(this.push) {
             this.log("Configuring Push");
@@ -671,7 +693,7 @@ export default class SmartELifeClient {
 
                 for(const listener of this.pushListeners) {
                     if(listener.pushType !== pushType) continue;
-                    listener.listener(title, body);
+                    this.dispatchPushListener(listener, title, body);
                 }
             });
             await this.push.connect();

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -597,13 +597,15 @@ export default class SmartELifeClient {
 
     private parsePushType(data: { [key: string]: unknown } | undefined, title?: string, body?: string): PushType {
         const pushType = this.parseRawPushType(data, title);
-        // The access (출입) push category covers the household front door, the communal
-        // door and the interphone camera alike; only the notification body tells them
-        // apart. Without this an unmapped `data4` falls back to the title and every one
-        // of them would resolve to FRONT_DOOR.
+        // The access (출입) push category covers the household front door,
+        // the communal door and the interphone camera alike;
+        // only the notification body tells them apart.
+        // Without this an unmapped `data4` falls back to the title,
+        // and every one of them would resolve to FRONT_DOOR.
         if(pushType === PushType.FRONT_DOOR && !!body) {
-            // A visitor snapshot is not tied to either door - the camera accessory reads
-            // `door_type` off the visitor board to decide which one it belongs to.
+            // A visitor snapshot is not tied to either door -
+            // the camera accessory reads `door_type` off the visitor board
+            // to decide which one it belongs to.
             if(body.includes("방문자")) {
                 return PushType.VISITOR;
             }

--- a/homebridge/accessories/smart-elife/camera.ts
+++ b/homebridge/accessories/smart-elife/camera.ts
@@ -155,14 +155,21 @@ export default class CameraAccessories extends Accessories<CameraAccessoryInterf
             this.log.warn("Could not fetch the list of visitors");
             return undefined;
         }
-        const snapshots: VisitorOnCameraInfo[] = response["data"]["list"]
+        // A `000` result does not guarantee the payload shape,
+        // and this runs off a push callback where a throw would take the bridge down.
+        const list = response["data"]?.["list"];
+        if(!Array.isArray(list)) {
+            this.log.warn("The visitor board returned no list: %s", JSON.stringify(response["data"]));
+            return undefined;
+        }
+        const snapshots: VisitorOnCameraInfo[] = list
             .map((e: any): VisitorOnCameraInfo => {
                 return {
                     cameraLocation: e["door_type"] as CameraLocation,
                     date: e["reg_num"],
                 };
             });
-        if(!snapshots || snapshots.length === 0) {
+        if(snapshots.length === 0) {
             this.log.warn("Could not fetch the list of visitors.");
             return undefined;
         }
@@ -204,6 +211,13 @@ export default class CameraAccessories extends Accessories<CameraAccessoryInterf
                 case CameraLocation.COMMUNAL_DOOR:
                     cameraDevice = EXTERIOR_COMMUNAL_DOOR_CAMERA_DEVICE;
                     break;
+                default:
+                    // `door_type` is cast from the wire without validation,
+                    // so an unexpected value would leave `cameraDevice` unassigned.
+                    // The raw value is logged because that is the only way
+                    // to notice the server renaming it.
+                    this.log.warn("Unknown visitor door_type, discarding the snapshot: %s", String(cameraInfo.cameraLocation));
+                    return;
             }
             const device = this.findDevice(cameraDevice.deviceId);
             if(!device)
@@ -227,12 +241,12 @@ export default class CameraAccessories extends Accessories<CameraAccessoryInterf
                 context.motionDetected = false;
 
                 accessory.getService(this.api.hap.Service.MotionSensor)
-                    ?.setCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
+                    ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
             }, (device.duration?.camera || CAMERA_TIMEOUT_DURATION) * 1000);
             context.motionDetected = true;
 
             accessory.getService(this.api.hap.Service.MotionSensor)
-                ?.setCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
+                ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
         });
         setTimeout(() => {
             for(const cameraDevice of [EXTERIOR_FRONT_DOOR_CAMERA_DEVICE, EXTERIOR_COMMUNAL_DOOR_CAMERA_DEVICE]) {


### PR DESCRIPTION
## Summary

The server swapped the data1/data2/data3 push payload for a single data4 code in July 2026, and the code for a saved visitor image (63) was left unmapped. It fell through to the title-based fallback and resolved to FRONT_DOOR, so PushType.VISITOR became unreachable and neither doorbell camera ever refreshed its snapshot. Related to #184 .

## Root cause

DATA4_PUSH_TYPES maps 55, 58 and 64, but not 63. An unmapped code falls back to TITLE_PUSH_TYPES, and both the visitor-image push and the communal-door push arrive under the same 출입 title, which maps to FRONT_DOOR. The visitor push therefore resolved to FRONT_DOOR, and the camera accessory's listener - registered for PushType.VISITOR - was never invoked. The front door's motion sensor fired in its place.

A second fault sat behind it. PushListener was declared () => void, but the camera's listener is async and fetches the snapshot over the network. TypeScript accepts that assignment, and the dispatcher called it bare, so a rejection surfaced as an unhandled rejection - which terminates the process on current Node. That path had not run since the payload format changed, so its failure modes had never been exercised.

## Changes

- Map data4: "63" to PushType.VISITOR.
- Refine an unmapped 출입 push by its body as well: "방문자" resolves to VISITOR, "공동" to COMMUNAL_DOOR. The mapping above already covers today's payload; this keeps the next unmapped code from collapsing into FRONT_DOOR the way 63 did.
- Widen PushListener to void | Promise<void> and dispatch through dispatchPushListener(), which catches both a synchronous throw and a rejection and reports it. Leaving the failure to the caller was considered and rejected: nothing upstream can act on it, and the alternative outcome is a dead bridge.
- Guard the visitor board's payload shape - a 000 result does not guarantee data.list is an array - and give the door_type switch a default that logs the raw value. door_type is cast from the wire without validation, and this same server changed its push format without notice.
- Reflect MotionDetected with updateCharacteristic rather than setCharacteristic at the two sites in this listener. State arriving from the server should not invoke the SET handler.

## Testing

- npm run build (type check).
- Ran on a real household - Homebridge on a Raspberry Pi, the plugin in a child bridge - and captured the live pushes: data4: "63" / 출입 / "방문자 이미지가 저장되었습니다." and data4: "64" / 출입 / "공동 현관 출입이 감지되었습니다.".
- Pressed the communal entrance doorbell and followed it end to end. The visitor push arrived at 18:12:00; board/visitor answered door_type: "lobby", reg_num: "2026-07-27 18:11:59"; board/visitor_detail answered 000 with a base64 JPEG; the communal doorbell camera resized a fresh snapshot in the same second and opened a stream five seconds later. The front door camera was left alone.
- The new door_type default branch did not fire, which confirms lobby still matches CameraLocation.COMMUNAL_DOOR.
- Not verified: the default branch and the payload-shape guard, neither of which triggered; and the daelim provider, which this change does not touch.