### PR TITLE
Fix the camera stream failing when HomeKit requests a resolution smaller than the source

### DIFF
--- a/core/camera-utils.ts
+++ b/core/camera-utils.ts
@@ -62,6 +62,31 @@ export function reformatSnapshot(processorPath: string, log: Logging, name: stri
     });
 }
 
+/**
+ * Builds the filter chain that fits a source frame into the requested box.
+ *
+ * The scale step targets the requested size directly,
+ * so a source larger than the request is shrunk instead of passed through.
+ * It has to be, because `pad` widens a canvas and cannot narrow one:
+ * handing it a frame larger than its target fails the whole graph
+ * with "Padded dimensions cannot be smaller than input dimensions".
+ * A source smaller than the request is still enlarged,
+ * and `pad` only fills whatever the aspect ratio leaves over.
+ */
+function buildResizeFilters(width: number, height: number): { resizeFilter: string, filters: Array<string> } {
+    const w = width > 0 ? width : "iw";
+    const h = height > 0 ? height : "ih";
+    const resizeFilter = `scale=${w}:${h}:force_original_aspect_ratio=decrease`;
+    return {
+        resizeFilter: resizeFilter,
+        filters: [
+            resizeFilter,
+            `pad=${w}:${h}:x=(${w}-iw)/2:y=(${h}-ih)/2:color=black`,
+            "scale=trunc(iw/2)*2:trunc(ih/2)*2" // Force to fit encoder restrictions
+        ]
+    };
+}
+
 interface SessionInfo {
     address: string // address of the HAP controller
     ipv6: boolean
@@ -212,10 +237,9 @@ export default class VisitorOnCameraStreamingDelegate implements CameraStreaming
         }
         resInfo.snapshotFilter = filters.join(",");
         if(noneFilter < 0 && (resInfo.width > 0 || resInfo.height > 0)) {
-            resInfo.resizeFilter = "scale=" + (resInfo.width > 0 ? "'max(" + resInfo.width + ",iw)'" : "iw") + ":" + (resInfo.height > 0 ? "'max(" + resInfo.height + ",ih)'" : "ih") + ":force_original_aspect_ratio=decrease";
-            filters.push(resInfo.resizeFilter);
-            filters.push(`pad=${resInfo.width > 0 ? resInfo.width : "iw"}:${resInfo.height > 0 ? resInfo.height : "ih"}:x=(${resInfo.width > 0 ? resInfo.width : "iw"}-iw)/2:y=(${resInfo.height > 0 ? resInfo.height : "ih"}-ih)/2:color=black`);
-            filters.push("scale=trunc(iw/2)*2:trunc(ih/2)*2"); // Force to fit encoder restrictions
+            const resize = buildResizeFilters(resInfo.width, resInfo.height);
+            resInfo.resizeFilter = resize.resizeFilter;
+            filters.push(...resize.filters);
         }
 
         if(filters.length > 0) {
@@ -324,10 +348,7 @@ export default class VisitorOnCameraStreamingDelegate implements CameraStreaming
             args.push(`-i ${backgroundPath}`);
             args.push("-frames:v 1");
 
-            const filters: string[] = [];
-            filters.push("scale=" + (resInfo.width > 0 ? "'max(" + resInfo.width + ",iw)'" : "iw") + ":" + (resInfo.height > 0 ? "'max(" + resInfo.height + ",ih)'" : "ih") + ":force_original_aspect_ratio=decrease");
-            filters.push(`pad=${resInfo.width > 0 ? resInfo.width : "iw"}:${resInfo.height > 0 ? resInfo.height : "ih"}:x=(${resInfo.width > 0 ? resInfo.width : "iw"}-iw)/2:y=(${resInfo.height > 0 ? resInfo.height : "ih"}-ih)/2:color=black`);
-            filters.push("scale=trunc(iw/2)*2:trunc(ih/2)*2");
+            const filters = buildResizeFilters(resInfo.width, resInfo.height).filters;
 
             const v0 = `format=rgba,colorchannelmixer=aa=${opacity.toFixed(5)},${filters.join(",")}[over]`;
             const v1 = `${filters.join(",")}[bg]`;


### PR DESCRIPTION
## Summary

The video filter chain scaled a source frame to `max(requested, source)` and then padded it to the requested size, so any stream negotiated below the source resolution failed to start: `pad` cannot narrow a canvas. Seven of the eleven advertised stream configurations were affected, including the 320x240 that the Apple Watch requires. Fixes #197 affecting #195

## Root cause

`determineResolution()` in `core/camera-utils.ts` built the scale step and the pad step against different targets. The scale target was `max(requested, source)`, which leaves a frame larger than the request untouched, while the pad that follows always targeted the requested size. Handing `pad` an input larger than its canvas fails the filter graph with "Padded dimensions cannot be smaller than input dimensions", so the encoder never opened and ffmpeg exited 234 without writing a packet.

`a88005d` (#68) introduced this. It changed the scale target from `min` to `max` and added the `pad` step in the same commit; while the target was `min` there was no pad for it to disagree with.

The bundled `assets/hksv_camera_idle.png` is 1280x720, so reproducing this needs no particular camera. Any stream negotiated below 1280 wide hits it.

## Changes

- The scale step now targets the requested dimensions directly. `force_original_aspect_ratio=decrease` already fits the frame inside that box, so oversized sources are shrunk, undersized sources are still enlarged, and `pad` goes back to filling only what the aspect ratio leaves over.
- Both call sites, `determineResolution()` and the transition-snapshot builder, assembled the same three filters by hand, which is why the defect existed in two places at once. They now share one helper, and its comment records the `pad` constraint so the target is not quietly reverted later.
- Reverting to the pre-#68 `min` was considered and rejected. `min` never enlarges, so a wall pad snapshot smaller than the request would render as a small image surrounded by black. `pad` already guarantees the output matches the negotiated resolution, so filling the box is the better default.
- The same filter drives snapshot resizing, which was quietly returning a full-size image for every downscaled request. The same change fixes it.

## Testing

- `npm run build` for the type check.
- Filter behaviour verified offline against the bundled 1280x720 idle image across all ten advertised resolutions. Before the change, the six below 1280 wide fail to configure; after it, all ten produce exactly the requested size.
- Enlargement of undersized sources is unchanged: a 320x180 source requested at 1280x720 produces 1280x720 both before and after.
- Edge cases exercised through the compiled `determineResolution()`: a zero width or height still falls back to `iw`/`ih`, `videoFilter: "none"` still suppresses the size filters, and the `forceMax` clamp still applies.
- On a Raspberry Pi running a local build, two live camera sessions that previously exited 234 with zero frames now work. 640x360 at 30 fps encoded 114 frames, and 320x240 at 15 fps, the Apple Watch configuration, encoded 89 frames. The snapshot resize filter was confirmed on the same device across five requests.
    - The 640x360 session came from an iPhone 17 Pro Max on iOS 26.6, joined over SKT LTE rather than the local network.
    - The 320x240 session came from an Apple Watch Series 7 on watchOS 26.6, paired to that phone.
    - Both were relayed through the home hub, so the plugin saw the same LAN endpoint for each.
- Not verified: the still-image video path, because no stream request arrived for the camera that uses it during the test window. It shares `determineResolution()` with the paths above.
- The device build also carried unrelated local changes. This fix does not depend on them.