### PR TITLE
Refuse the device reports that belong to another household

### DIFF
--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -98,6 +98,14 @@ export interface DeviceFetchResult {
     household: HouseholdAttribution
     /** Empty when the attribution is `FOREIGN` or `INVALID` - failure is not an empty household. */
     devices: Device[]
+    /**
+     * The room each device is in, by device id - the name the resident gave it on the
+     * WallPad, falling back to the canonical room name where none was given.
+     * Display-only and never saved: the wizard's confirmation screen shows it because
+     * a resident recognises their own home by the names they chose,
+     * not by the canonical room names the display names are built from.
+     */
+    aliases: Record<string, string>
 }
 
 /**
@@ -1272,9 +1280,21 @@ export default class SmartELifeClient {
             } else {
                 this.log.warn("The rendered page carried no readable device list, so no devices were read.");
             }
-            return { household: page.household, devices: [] };
+            return { household: page.household, devices: [], aliases: {} };
         }
         const deviceList = page.deviceList;
+        // Collected on its own rather than inside the loop below,
+        // so the reading of a device stays one thing and the naming of its room another.
+        const aliases: Record<string, string> = {};
+        for(const deviceGroup of deviceList) {
+            for(const device of deviceGroup?.["devices"] || []) {
+                const deviceId = device?.["uid"];
+                const alias = device?.["location_name_alias"] || device?.["location_name"];
+                if(typeof deviceId === "string" && typeof alias === "string" && alias.length > 0) {
+                    aliases[deviceId] = alias;
+                }
+            }
+        }
         const fetchedDevices: Device[] = [];
         for(const deviceGroup of deviceList) {
             const deviceType = deviceGroup["type"] as DeviceType || DeviceType.UNKNOWN;
@@ -1298,7 +1318,7 @@ export default class SmartELifeClient {
                 });
             }
         }
-        return { household: page.household, devices: fetchedDevices };
+        return { household: page.household, devices: fetchedDevices, aliases };
     }
 
     private async fetchComplex() {

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -167,11 +167,13 @@ export default class SmartELifeClient {
 
                 let status = "000";
                 let deviceTypeString, message;
+                let completeSnapshot = false;
                 if(!!header) {
                     deviceTypeString = header["type"];
                     if(header["command"] === "control_response")
                         return;
 
+                    completeSnapshot = true;
                     if(json["result"]) {
                         status = json["result"]["status"];
                         message = json["result"]["message"];
@@ -190,6 +192,15 @@ export default class SmartELifeClient {
                 const deviceType = deviceTypeString as DeviceType || DeviceType.UNKNOWN;
                 if(deviceType === DeviceType.UNKNOWN)
                     client.log.warn("Unknown device type: %s", deviceTypeString);
+
+                // The socket carries the same misattribution the rendered page does.
+                // A day of measurement found 91 answers that listed another household's devices.
+                if(!client.isOwnHouseholdFrame(json["data"], completeSnapshot, deviceType)) {
+                    client.declinedForeignReports += 1;
+                    client.log.debug("Ignoring a %s frame that is not this household's " +
+                        "(%d report(s) declined so far).", deviceTypeString, client.declinedForeignReports);
+                    return;
+                }
 
                 for(const info of client.listeners) {
                     if(info.deviceType === deviceType) {
@@ -995,6 +1006,43 @@ export default class SmartELifeClient {
             return true;
         }
         return ours * 2 > listed;
+    }
+
+    /**
+     * Whether a WebSocket frame is this household's.
+     *
+     * The two shapes have to be judged differently. A query answers with every device of its
+     * type, which can be held against the configuration exactly as a page is - 91 of these
+     * arrived from other households in a day of measurement. A push carries one device, where
+     * a majority means nothing, but it does carry the room key, which the elevator frames
+     * already rely on. A frame naming neither is let through: `elevator_call_request` carries
+     * no room key at all.
+     */
+    private isOwnHouseholdFrame(data: any, completeSnapshot: boolean, deviceType: DeviceType): boolean {
+        // Not every frame carries devices at all - the indoor air list answers with a bare
+        // header - and a frame that names nothing cannot be attributed to anybody.
+        if(!data || typeof data !== "object") {
+            return true;
+        }
+        if(completeSnapshot) {
+            // A whole page pools every type, so a handful of devices this household never
+            // configured is lost in the majority. One type on its own has no such cushion:
+            // where the configuration holds none of that type at all, every answer about it
+            // names nobody we know and would read as somebody else's. The all-off switch is
+            // exactly that - `fetchDevices()` never writes it down - and its own answers were
+            // being refused. Judge only what there is something to judge against.
+            const comparable = (this.config.devices || [])
+                .some((device) => device.deviceType === deviceType);
+            if(!comparable) {
+                return true;
+            }
+            return this.isOwnHouseholdDeviceList([data]);
+        }
+        const roomKey = data["roomkey"];
+        if(typeof roomKey !== "string" || roomKey.length === 0) {
+            return true;
+        }
+        return !this.wsCredentials?.roomKey || roomKey === this.wsCredentials.roomKey;
     }
 
     /**

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -132,6 +132,40 @@ interface RenderedPage {
 
 const POLLING_INTERVAL_MILLISECONDS = 30 * 1000;
 
+/**
+ * How many recorded status queries one device type may have in flight.
+ *
+ * A healthy queue is zero or one deep - answers arrive in under a second and polls are
+ * thirty seconds apart - so hitting the cap means answers stopped coming. A type at the
+ * cap is not asked again until its outstanding answers arrive or a reconnect clears them:
+ * sending without recording would let the unmatched answer drain to an empty queue and
+ * wear a receive stamp, ranking a stale observation as the newest thing yet, and removing
+ * entries instead would hand an old answer a newer query's number. Going quiet is the one
+ * option that cannot misrank anything - it costs queries against a WallPad that is not
+ * answering them anyway.
+ *
+ * A poll that lands between a reconnect starting and `onOpen` clearing the queues still
+ * skips a type the dead connection had capped out, deferring its fallback query to the
+ * next poll. Accepted: it costs at most one poll period of backstop freshness in an
+ * already-blind window, pushes resume with the connection either way, and remembering
+ * skipped types across a reconnect would need exactly the generation bookkeeping this
+ * design just got rid of.
+ */
+const MAX_PENDING_STATUS_QUERIES = 4;
+
+/**
+ * Device types whose state never comes back as a header snapshot - their accessories are
+ * driven by pushes and by `elevator_call_*`/`elevate_call` action frames instead. Asking
+ * the WallPad about one of these would record a status query that no answer ever consumes,
+ * leaving the recorded number to desynchronize that type's queue for good.
+ */
+const UNQUERYABLE_DEVICE_TYPES = new Set<DeviceType>([
+    DeviceType.ELEVATOR,
+    DeviceType.DOOR,
+    DeviceType.VEHICLE,
+    DeviceType.CAMERA,
+]);
+
 export default class SmartELifeClient {
 
     // Some networks (notably IPv6-only/NAT64) can resolve this host to both IPv4 and IPv6,
@@ -184,9 +218,25 @@ export default class SmartELifeClient {
      * Numbers drawn for status queries whose answers have not arrived yet, per type.
      * FIFO: the socket answers queries of one type in the order they were sent,
      * so the head of the queue always belongs to the next answer.
+     *
+     * An entry is reserved synchronously as the frame is handed to the socket -
+     * see `sendStatusQuery` for why no other moment works - and a type at
+     * `MAX_PENDING_STATUS_QUERIES` unanswered queries is not asked again,
+     * keeping sends and entries one-to-one.
      * Cleared on reconnect - see `onOpen`.
      */
     private readonly pendingStatusQueries = new Map<DeviceType, number[]>();
+
+    /**
+     * Slots claimed by status queries that passed the cap check but whose send has not
+     * settled yet, per type. Claimed synchronously with the check itself, so concurrent
+     * calls started in the same tick see each other and cannot pass the cap together -
+     * the reservation in `pendingStatusQueries` only lands later, at each call's send
+     * moment. Released when the send settles; between the reservation landing and the
+     * release a type is briefly counted twice, which can only defer a query, never
+     * admit one too many.
+     */
+    private readonly inFlightStatusQueries = new Map<DeviceType, number>();
 
     /** How many reports were declined as another household's, for the debug log. */
     private declinedForeignReports = 0;
@@ -288,6 +338,16 @@ export default class SmartELifeClient {
                     const queued = client.pendingStatusQueries.get(deviceType)?.shift();
                     if(queued !== undefined) {
                         observedSeq = queued;
+                    } else {
+                        // The one residual too-new window. The protocol carries no
+                        // correlation id, so a header frame this client never asked for
+                        // (the server answers for the household, not the session) consumes
+                        // the head meant for a real answer, and the answer then arrives
+                        // to an empty queue and keeps the receive stamp - bounded by one
+                        // round trip, realigned by the very next answer. Logged so the
+                        // field frequency is a number rather than a guess.
+                        client.log.debug("A %s snapshot arrived with no status query on record; " +
+                            "keeping its receive stamp.", deviceTypeString);
                     }
                 }
 
@@ -963,9 +1023,13 @@ export default class SmartELifeClient {
             await this.refreshDeviceStatus();
         }
 
-        setInterval(async () => {
+        setInterval(() => {
             this.log.info("Polling device state");
-            await this.refreshDeviceStatus(true);
+            // Wrapped so a rejected poll (network failure, socket teardown) is logged
+            // instead of surfacing as an unhandled promise rejection.
+            this.refreshDeviceStatus(true).catch((e: any) => {
+                this.log.warn("Device state polling failed: %s", e?.message || e);
+            });
         }, POLLING_INTERVAL_MILLISECONDS);
     }
 
@@ -1180,14 +1244,17 @@ export default class SmartELifeClient {
      * account of which types it answers for. Before then the configuration stands in, because
      * the first page after a sign-in is sometimes the one that gets declined, and a start that
      * declines its first page would otherwise ask about nothing at all and sit blind until a
-     * page happens to come back ours. A type the query cannot answer for costs one entry in a
-     * JSON array and is ignored.
+     * page happens to come back ours.
+     *
+     * Types that never answer as a header snapshot are left out of both sources -
+     * see `UNQUERYABLE_DEVICE_TYPES`. The configuration always lists the exterior
+     * devices, and every query about one of them would go unanswered forever.
      */
     private deviceTypesToAskAbout(): DeviceType[] {
-        if(this.renderedDeviceTypes.length > 0) {
-            return this.renderedDeviceTypes;
-        }
-        return [...new Set((this.config.devices || []).map((device) => device.deviceType))];
+        const deviceTypes = this.renderedDeviceTypes.length > 0
+            ? this.renderedDeviceTypes
+            : [...new Set((this.config.devices || []).map((device) => device.deviceType))];
+        return deviceTypes.filter((deviceType) => !UNQUERYABLE_DEVICE_TYPES.has(deviceType));
     }
 
     /**
@@ -1202,9 +1269,10 @@ export default class SmartELifeClient {
         if(!this.ws || deviceTypes.length === 0) {
             return;
         }
-        await this.sendStatusQuery(
-            deviceTypes.map((deviceType) => ({ type: deviceType.toString() })),
-            deviceTypes);
+        await this.sendStatusQuery(deviceTypes.map((deviceType) => ({
+            payload: { type: deviceType.toString() },
+            deviceType,
+        })));
     }
 
     /**
@@ -1212,19 +1280,90 @@ export default class SmartELifeClient {
      * The answers arrive through `onMessage` as complete snapshots and pick these numbers
      * back up in order - see `ListenerMetadata.observedSeq` for why the send is the moment
      * that counts.
+     *
+     * The invariant is one recorded entry per sent query, in both directions, and the
+     * reservation is installed at the only moment that satisfies both: synchronously as
+     * the frame is handed to the socket, via the scheduler's `beforeSend` hook. Any
+     * earlier and a reconnect the send rides through wipes it while the frame still
+     * goes out; any later and the answer can beat it there, because a busy event loop
+     * dispatches the read before the pending send callback. Either mistake strands
+     * phantom entries that nothing ever consumes, and phantoms latch the cap shut.
+     * A send the scheduler never attempts never runs the hook, so it reserves nothing.
+     *
+     * A send whose callback errors is ambiguous - the peer may have parsed the frame
+     * and answered before the failure was reported - so its reservation deliberately
+     * stays: an answer that does come consumes it, one that never comes is collected
+     * by the reconnect clear, and the cost in the meantime is answers of the type
+     * wearing a number one query too old, which a command survives.
+     *
+     * The numbers are still drawn at the call, before any waiting: a command fired
+     * while the send is blocked must outrank the answer. Reservation order is send
+     * order, so every answer consumes a head no newer than its own pre-send number -
+     * a report can wear too old a number, never too new a one.
+     *
+     * A type whose queue is full is left out of the query itself, not merely out of the
+     * record: an unrecorded query would still be answered, and once the queue drains,
+     * that unmatched answer would wear a receive stamp - a stale observation ranked as
+     * the newest thing yet. Not asking again until the outstanding answers arrive (or a
+     * reconnect clears them) is the only outcome that cannot misrank anything. The
+     * check counts what the batch itself is about to reserve and what concurrent calls
+     * have claimed but not yet reserved - see `inFlightStatusQueries` - so neither
+     * duplicate types in one batch nor calls started in the same tick can pass the
+     * cap together.
      */
-    private async sendStatusQuery(data: any[], deviceTypes: DeviceType[]) {
-        for(const deviceType of deviceTypes) {
-            const queue = this.pendingStatusQueries.get(deviceType) || [];
-            queue.push(this.takeObservedSeq());
-            this.pendingStatusQueries.set(deviceType, queue);
-        }
-        await this.sendJson({
-            "roomKey": this.wsCredentials?.roomKey,
-            "userKey": this.wsCredentials?.userKey,
-            "accessToken": this.wsCredentials?.accessToken,
-            "data": data,
+    private async sendStatusQuery(queries: { payload: any, deviceType: DeviceType }[]) {
+        const projectedDepths = new Map<DeviceType, number>();
+        const sendable = queries.filter(({ deviceType }) => {
+            const projected = projectedDepths.get(deviceType) || 0;
+            const depth = (this.pendingStatusQueries.get(deviceType)?.length || 0)
+                + (this.inFlightStatusQueries.get(deviceType) || 0)
+                + projected;
+            if(depth >= MAX_PENDING_STATUS_QUERIES) {
+                this.log.debug("Not asking about %s: %d earlier queries are still unanswered.",
+                    deviceType, depth);
+                return false;
+            }
+            projectedDepths.set(deviceType, projected + 1);
+            return true;
         });
+        if(sendable.length === 0) {
+            return;
+        }
+        // Still inside the synchronous block the cap was checked in.
+        for(const { deviceType } of sendable) {
+            this.inFlightStatusQueries.set(deviceType,
+                (this.inFlightStatusQueries.get(deviceType) || 0) + 1);
+        }
+        const drawnSeqs = sendable.map(() => this.takeObservedSeq());
+        const reserve = () => {
+            sendable.forEach(({ deviceType }, index) => {
+                const queue = this.pendingStatusQueries.get(deviceType) || [];
+                queue.push(drawnSeqs[index]);
+                this.pendingStatusQueries.set(deviceType, queue);
+            });
+        };
+        try {
+            await this.sendJson({
+                "roomKey": this.wsCredentials?.roomKey,
+                "userKey": this.wsCredentials?.userKey,
+                "accessToken": this.wsCredentials?.accessToken,
+                "data": sendable.map(({ payload }) => payload),
+            }, reserve);
+        } catch (e: any) {
+            // The scheduler rethrows what is not a close race (open timeout,
+            // re-sign-in failure). None of it is this query's problem to escalate -
+            // the poll retries in thirty seconds either way.
+            this.log.warn("Could not send a status query: %s", e?.message || e);
+        } finally {
+            for(const { deviceType } of sendable) {
+                const remaining = (this.inFlightStatusQueries.get(deviceType) || 0) - 1;
+                if(remaining > 0) {
+                    this.inFlightStatusQueries.set(deviceType, remaining);
+                } else {
+                    this.inFlightStatusQueries.delete(deviceType);
+                }
+            }
+        }
     }
 
     private async refreshDeviceStatus(forceFetch: boolean = false) {
@@ -1243,9 +1382,14 @@ export default class SmartELifeClient {
             return;
         }
         const deviceList = page.deviceList;
-        await this.sendStatusQuery(deviceList, deviceList
-            .map((deviceGroup: any) => deviceGroup["type"] as DeviceType)
-            .filter((deviceType: DeviceType) => !!deviceType));
+        // A group without a type could not be recorded, so it is not asked about either -
+        // the same one-entry-per-sent-query invariant `sendStatusQuery` keeps at its cap.
+        await this.sendStatusQuery(deviceList
+            .map((deviceGroup: any) => ({
+                payload: deviceGroup,
+                deviceType: deviceGroup["type"] as DeviceType,
+            }))
+            .filter(({ deviceType }) => !!deviceType));
 
         for(const deviceGroup of deviceList) {
             const deviceType = deviceGroup["type"] as DeviceType || DeviceType.UNKNOWN;
@@ -1415,8 +1559,8 @@ export default class SmartELifeClient {
         return response["result"] as boolean;
     }
 
-    async sendJson(payload: any) {
-        await this.ws?.wsSendJson(payload);
+    async sendJson(payload: any, beforeSend?: () => void): Promise<boolean> {
+        return await this.ws?.wsSendJson(payload, beforeSend) ?? false;
     }
 
     addListener(deviceType: DeviceType, listener: Listener) {

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -72,6 +72,30 @@ interface PushListenerInfo {
 }
 
 /**
+ * Which household a device report belongs to.
+ *
+ * `OWN` and `FOREIGN` are the two answers; the other two say the question
+ * could not be answered. `UNKNOWN` means there was nothing to hold the list
+ * against - a first-time setup - and `INVALID` means the markup gave the
+ * parser nothing, so the question could not even be posed.
+ *
+ * String-valued so the wizard can carry it to the frontend as an event reason.
+ */
+export enum HouseholdAttribution {
+    OWN = "own",
+    FOREIGN = "foreign",
+    UNKNOWN = "unknown",
+    INVALID = "invalid",
+}
+
+/** What `fetchDevices()` found, and whose household it judged the list to be. */
+export interface DeviceFetchResult {
+    household: HouseholdAttribution
+    /** Empty when the attribution is `FOREIGN` or `INVALID` - failure is not an empty household. */
+    devices: Device[]
+}
+
+/**
  * A `/main/home.do` that was held against the configuration and kept.
  * The stamp rides with the markup rather than being taken where it is parsed:
  * the polled page is already seconds old by then,
@@ -83,11 +107,11 @@ interface RenderedPage {
     deviceList: any[] | undefined
 
     /**
-     * Whether the devices this page listed are this household's.
+     * Whose household the devices this page listed belong to.
      * The session keys it carries are ours either way - measured - so the credentials
      * parser reads the page regardless, while everything about the devices does not.
      */
-    ownHousehold: boolean
+    household: HouseholdAttribution
 
     observedSeq: number
     observedAt: number
@@ -990,13 +1014,12 @@ export default class SmartELifeClient {
             headers: await this.createDocumentHeaters(),
         }).then((response) => response.text());
 
-        // A page whose markup gave the parser nothing says nothing about which household
-        // answered either, so it is carried rather than declined - the credentials parser
-        // reads the same page for something the device list has no bearing on.
         const deviceList = parseDeviceList(html) || undefined;
-        const ownHousehold = !deviceList || this.isOwnHouseholdDeviceList(deviceList);
-        const page: RenderedPage = { html, deviceList, ownHousehold, observedSeq, observedAt };
-        if(!ownHousehold) {
+        const household = !deviceList
+            ? HouseholdAttribution.INVALID
+            : this.attributeDeviceList(deviceList);
+        const page: RenderedPage = { html, deviceList, household, observedSeq, observedAt };
+        if(household === HouseholdAttribution.FOREIGN) {
             this.declinedForeignReports += 1;
             this.log.debug("Ignoring a rendered page that is not this household's " +
                 "(%d report(s) declined so far).", this.declinedForeignReports);
@@ -1004,8 +1027,22 @@ export default class SmartELifeClient {
             // the household for as long as nobody forces a fetch.
             return page;
         }
+        if(household === HouseholdAttribution.INVALID) {
+            // A page the parser could not read is not cached either - unlike a foreign page
+            // it says nothing about any household, but serving it again would pin every
+            // downstream reader to markup that already failed once. The caller still gets
+            // the page itself: the credentials parser reads it for something the device
+            // list has no bearing on.
+            this.log.debug("The rendered page carried no readable device list.");
+            return page;
+        }
+        // OWN and UNKNOWN are both kept. An UNKNOWN page is the candidate a first-time
+        // setup shows the resident, and it has to stay one page - refetching between the
+        // credentials parse and the device read could swap in a different household's.
         this.renderedPage = page;
-        if(deviceList) {
+        if(household === HouseholdAttribution.OWN && deviceList) {
+            // Learned only from a page that proved itself ours - an unproven page must not
+            // decide which device types the WallPad gets asked about.
             this.renderedDeviceTypes = deviceList
                 .map((deviceGroup: any) => deviceGroup["type"] as DeviceType)
                 .filter((deviceType: DeviceType) => !!deviceType);
@@ -1014,7 +1051,7 @@ export default class SmartELifeClient {
     }
 
     /**
-     * Whether a device list is this household's.
+     * Whose household a device list is.
      *
      * WallPad `uid`s are only unique inside one household, so a stranger's list does not
      * merely miss ours - it collides with a few of them, and `parseDevices()` matches on
@@ -1023,20 +1060,20 @@ export default class SmartELifeClient {
      * Measured against a live household over a day: this account's own page names all but one
      * of the devices it lists in the configuration, while the pages of strangers name at most a
      * fifth of theirs. A majority sits between the two with room to spare on both sides.
+     *
+     * Where there is nothing to compare against, the answer is `UNKNOWN` rather than a pass:
+     * the settings wizard shows such a list to the resident,
+     * and only what they explicitly save becomes the yardstick for every later judgement.
      */
-    private isOwnHouseholdDeviceList(deviceList: any[]): boolean {
+    private attributeDeviceList(deviceList: any[]): HouseholdAttribution {
         const configured = new Set((this.config.devices || []).map((device) => device.deviceId));
         // Nothing to hold the list against.
-        // The settings wizard signs in precisely to find out what this household has,
-        // and the resident then reads that list on screen and saves it -
-        // which is the confirmation this judgement would otherwise be standing in for.
         if(configured.size === 0) {
             if(!this.reportedUncomparableDeviceList) {
                 this.reportedUncomparableDeviceList = true;
-                this.log.debug("Nothing configured to hold a device list against; " +
-                    "accepting it as this household's.");
+                this.log.debug("Nothing configured to hold a device list against.");
             }
-            return true;
+            return HouseholdAttribution.UNKNOWN;
         }
         let listed = 0;
         let ours = 0;
@@ -1053,12 +1090,11 @@ export default class SmartELifeClient {
             }
         }
         // A list that named nobody carries no state to mistake for ours,
-        // so there is nothing to protect against and something to lose by refusing:
-        // a household part-way through setup would never get past this.
+        // and no evidence about whose it is either.
         if(listed === 0) {
-            return true;
+            return HouseholdAttribution.UNKNOWN;
         }
-        return ours * 2 > listed;
+        return ours * 2 > listed ? HouseholdAttribution.OWN : HouseholdAttribution.FOREIGN;
     }
 
     /**
@@ -1089,7 +1125,9 @@ export default class SmartELifeClient {
             if(!comparable) {
                 return true;
             }
-            return this.isOwnHouseholdDeviceList([data]);
+            // Only a positive FOREIGN verdict declines a frame. UNKNOWN passes as before -
+            // with nothing configured there are no accessories listening anyway.
+            return this.attributeDeviceList([data]) !== HouseholdAttribution.FOREIGN;
         }
         const roomKey = data["roomkey"];
         if(typeof roomKey !== "string" || roomKey.length === 0) {
@@ -1140,11 +1178,13 @@ export default class SmartELifeClient {
             return;
         }
         const page = await this.fetchRenderedPage(forceFetch);
-        if(!page.ownHousehold || !page.deviceList) {
+        if(page.household === HouseholdAttribution.FOREIGN || !page.deviceList) {
             // Nothing of this page reaches the accessories, and none of it is echoed back
             // to the socket either - asking the server about a stranger's devices is how
             // their answers came back as ours. The WallPad is asked instead, so that
             // declining a page costs freshness rather than sight.
+            // An UNKNOWN page passes: with nothing configured there are no accessories
+            // listening, so publishing it is a no-op rather than a leak.
             await this.requestDeviceStatus();
             return;
         }
@@ -1177,17 +1217,19 @@ export default class SmartELifeClient {
         await this.sendJson(createElevatorStatusRequest(this.getWebSocketCredentials()));
     }
 
-    async fetchDevices(): Promise<Device[]> {
+    async fetchDevices(): Promise<DeviceFetchResult> {
         const page = await this.fetchRenderedPage();
-        if(!page.ownHousehold || !page.deviceList) {
-            // A wizard signing in for the first time has nothing to hold a page against,
-            // so it never reaches this - the judgement is skipped and the resident reads
-            // the list on screen instead. Getting here means a saved configuration exists
-            // and the page did not match it, which is worth saying rather than answering
-            // with an empty household.
-            this.log.warn("The rendered device list was not this household's, so no devices were read. " +
-                "Try again in a moment.");
-            return [];
+        if(page.household === HouseholdAttribution.FOREIGN || !page.deviceList) {
+            // Failure is reported as what it is rather than as an empty household -
+            // the wizard decides what to do with it, and must not mistake it for
+            // a home that owns no devices.
+            if(page.household === HouseholdAttribution.FOREIGN) {
+                this.log.warn("The rendered device list was not this household's, so no devices were read. " +
+                    "Try again in a moment.");
+            } else {
+                this.log.warn("The rendered page carried no readable device list, so no devices were read.");
+            }
+            return { household: page.household, devices: [] };
         }
         const deviceList = page.deviceList;
         const fetchedDevices: Device[] = [];
@@ -1213,7 +1255,7 @@ export default class SmartELifeClient {
                 });
             }
         }
-        return fetchedDevices;
+        return { household: page.household, devices: fetchedDevices };
     }
 
     private async fetchComplex() {

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -34,9 +34,28 @@ export interface ListenerError {
 export interface ListenerMetadata {
     /** WebSocket action name, e.g. `elevate_call`. Absent on a polled report. */
     action?: string
+
+    /**
+     * Number drawn from the client's observation counter
+     * at the moment this observation was *requested*.
+     * Commands draw from the same counter,
+     * so a report numbered below a command cannot say anything about that command -
+     * the poll it came from was already in the air when the command was sent.
+     */
+    observedSeq: number
+
+    /**
+     * Whether this report is the whole of its device type rather than a single device.
+     * A polled page and the answer to a query both are;
+     * an `event_*` push carries the one device that changed.
+     */
+    completeSnapshot: boolean
+
+    /** Wall clock at the same instant. For the log, and never compared - see `observedSeq`. */
+    observedAt: number
 }
 
-export type Listener = (data: any | undefined, error: ListenerError, metadata?: ListenerMetadata) => void;
+export type Listener = (data: any | undefined, error: ListenerError, metadata: ListenerMetadata) => void;
 // A listener may run asynchronously - the camera one fetches the visitor snapshot
 // over the network - so the return type has to admit a promise
 // for the dispatcher to be able to catch its rejection.
@@ -69,6 +88,9 @@ interface RenderedPage {
      * parser reads the page regardless, while everything about the devices does not.
      */
     ownHousehold: boolean
+
+    observedSeq: number
+    observedAt: number
 }
 
 const POLLING_INTERVAL_MILLISECONDS = 30 * 1000;
@@ -105,6 +127,14 @@ export default class SmartELifeClient {
     // WallPad authorization temporary keys
     private wsCredentials?: WebSocketCredentials;
     private renderedPage?: RenderedPage;
+
+    /**
+     * Draws the numbers that order observations against commands.
+     * A wall clock cannot: a Raspberry Pi has no RTC and steps its clock
+     * once the network comes up, and two events inside one millisecond
+     * are indistinguishable by it either way.
+     */
+    private observationCounter = 0;
 
     /**
      * Device types the last accepted page carried.
@@ -162,11 +192,18 @@ export default class SmartELifeClient {
                 await client.requestElevatorStatus();
             },
             async onMessage(client: SmartELifeClient, json: any) {
+                // Stamped where the frame is received. Everything below is parsing.
+                const observedSeq = client.takeObservedSeq();
+                const observedAt = Date.now();
+
                 const header = json["header"];
                 const action = json["action"];
 
                 let status = "000";
                 let deviceTypeString, message;
+                // A query answers with every device of the type it was asked about.
+                // An `event_*` push carries the one device that changed,
+                // and publishing from it would mix what just arrived with what is still stale.
                 let completeSnapshot = false;
                 if(!!header) {
                     deviceTypeString = header["type"];
@@ -204,7 +241,8 @@ export default class SmartELifeClient {
 
                 for(const info of client.listeners) {
                     if(info.deviceType === deviceType) {
-                        info.listener(json["data"], { code: Number(status), message }, { action });
+                        info.listener(json["data"], { code: Number(status), message },
+                            { action, observedSeq, observedAt, completeSnapshot });
                     }
                 }
             }
@@ -920,6 +958,16 @@ export default class SmartELifeClient {
     }
 
     /**
+     * Next number from the observation counter.
+     * Observations and commands draw from the same one,
+     * which is the only thing that establishes their order -
+     * see `ListenerMetadata.observedSeq`.
+     */
+    takeObservedSeq(): number {
+        return ++this.observationCounter;
+    }
+
+    /**
      * Fetches `/main/home.do` and keeps it only if it is this household's.
      *
      * The single gate. `/main/home.do` answers with another resident's page often enough
@@ -932,6 +980,11 @@ export default class SmartELifeClient {
         if(!!this.renderedPage && !forceFetch) {
             return this.renderedPage;
         }
+        // Stamped before the request leaves rather than after the markup is read.
+        // A polled page is seconds old by the time it is parsed,
+        // and a command sent in that gap must not be judged against it.
+        const observedSeq = this.takeObservedSeq();
+        const observedAt = Date.now();
         const html = await this.fetchWithJSessionId(`${this.baseUrl}/main/home.do`, {
             method: "GET",
             headers: await this.createDocumentHeaters(),
@@ -942,7 +995,7 @@ export default class SmartELifeClient {
         // reads the same page for something the device list has no bearing on.
         const deviceList = parseDeviceList(html) || undefined;
         const ownHousehold = !deviceList || this.isOwnHouseholdDeviceList(deviceList);
-        const page: RenderedPage = { html, deviceList, ownHousehold };
+        const page: RenderedPage = { html, deviceList, ownHousehold, observedSeq, observedAt };
         if(!ownHousehold) {
             this.declinedForeignReports += 1;
             this.log.debug("Ignoring a rendered page that is not this household's " +
@@ -1111,7 +1164,11 @@ export default class SmartELifeClient {
             for(const listener of this.listeners) {
                 if(listener.deviceType !== deviceType)
                     continue;
-                listener.listener(deviceGroup, { code: Number("000"), message: undefined });
+                listener.listener(deviceGroup, { code: Number("000"), message: undefined }, {
+                    observedSeq: page.observedSeq,
+                    observedAt: page.observedAt,
+                    completeSnapshot: true,
+                });
             }
         }
     }

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -32,6 +32,7 @@ export interface ListenerError {
 }
 
 export interface ListenerMetadata {
+    /** WebSocket action name, e.g. `elevate_call`. Absent on a polled report. */
     action?: string
 }
 
@@ -49,6 +50,25 @@ interface ListenerInfo {
 interface PushListenerInfo {
     pushType: PushType
     listener: PushListener
+}
+
+/**
+ * A `/main/home.do` that was held against the configuration and kept.
+ * The stamp rides with the markup rather than being taken where it is parsed:
+ * the polled page is already seconds old by then,
+ * and what decides whether a report may be believed
+ * is when it was asked for, not when it was read.
+ */
+interface RenderedPage {
+    html: string
+    deviceList: any[] | undefined
+
+    /**
+     * Whether the devices this page listed are this household's.
+     * The session keys it carries are ours either way - measured - so the credentials
+     * parser reads the page regardless, while everything about the devices does not.
+     */
+    ownHousehold: boolean
 }
 
 const POLLING_INTERVAL_MILLISECONDS = 30 * 1000;
@@ -84,7 +104,20 @@ export default class SmartELifeClient {
 
     // WallPad authorization temporary keys
     private wsCredentials?: WebSocketCredentials;
-    private serverSideRenderedHTML?: string;
+    private renderedPage?: RenderedPage;
+
+    /**
+     * Device types the last accepted page carried.
+     * Learned rather than listed, so that a household whose WallPad answers for
+     * something this plugin has never seen is asked about it all the same.
+     */
+    private renderedDeviceTypes: DeviceType[] = [];
+
+    /** How many reports were declined as another household's, for the debug log. */
+    private declinedForeignReports = 0;
+
+    /** Whether the log has already said that there is nothing to hold a report against. */
+    private reportedUncomparableDeviceList = false;
 
     private readonly ws?: WebSocketScheduler;
     private readonly listeners: ListenerInfo[] = [];
@@ -487,7 +520,13 @@ export default class SmartELifeClient {
     }
 
     private async attemptsParsingWebSocketCredentials() {
-        let { userKey, roomKey, accessToken } = parseWebSocketCredentials(await this.fetchServerSideRenderedHTML());
+        // Reads the page whichever household its device list belonged to.
+        // Measured over a day: every page carried this session's own room and user keys,
+        // including the ones whose device list was somebody else's - the server misresolves
+        // the household for the list, not for the session. Declining here would leave a
+        // working session without the credentials it needs.
+        const { html } = await this.fetchRenderedPage();
+        let { userKey, roomKey, accessToken } = parseWebSocketCredentials(html);
 
         userKey = userKey || this.config.userKey || "";
         roomKey = roomKey || this.config.roomKey || "";
@@ -869,23 +908,146 @@ export default class SmartELifeClient {
         return r.version;
     }
 
-    private async fetchServerSideRenderedHTML(forceFetch: boolean = false) {
-        if(!!this.serverSideRenderedHTML && !forceFetch) {
-            return this.serverSideRenderedHTML;
+    /**
+     * Fetches `/main/home.do` and keeps it only if it is this household's.
+     *
+     * The single gate. `/main/home.do` answers with another resident's page often enough
+     * to matter - measured at 18 to 42 per cent of polls over a day - and it does so with a
+     * plain 200 rather than with anything that reads as an error. Everything downstream reads
+     * this page: the device list, the room names, the WebSocket credentials. Holding the page
+     * itself is the only place where one judgement covers all of them.
+     */
+    private async fetchRenderedPage(forceFetch: boolean = false): Promise<RenderedPage> {
+        if(!!this.renderedPage && !forceFetch) {
+            return this.renderedPage;
         }
         const html = await this.fetchWithJSessionId(`${this.baseUrl}/main/home.do`, {
             method: "GET",
             headers: await this.createDocumentHeaters(),
         }).then((response) => response.text());
-        this.serverSideRenderedHTML = html;
-        return html;
+
+        // A page whose markup gave the parser nothing says nothing about which household
+        // answered either, so it is carried rather than declined - the credentials parser
+        // reads the same page for something the device list has no bearing on.
+        const deviceList = parseDeviceList(html) || undefined;
+        const ownHousehold = !deviceList || this.isOwnHouseholdDeviceList(deviceList);
+        const page: RenderedPage = { html, deviceList, ownHousehold };
+        if(!ownHousehold) {
+            this.declinedForeignReports += 1;
+            this.log.debug("Ignoring a rendered page that is not this household's " +
+                "(%d report(s) declined so far).", this.declinedForeignReports);
+            // Deliberately not cached. Serving it again would make one bad answer
+            // the household for as long as nobody forces a fetch.
+            return page;
+        }
+        this.renderedPage = page;
+        if(deviceList) {
+            this.renderedDeviceTypes = deviceList
+                .map((deviceGroup: any) => deviceGroup["type"] as DeviceType)
+                .filter((deviceType: DeviceType) => !!deviceType);
+        }
+        return page;
+    }
+
+    /**
+     * Whether a device list is this household's.
+     *
+     * WallPad `uid`s are only unique inside one household, so a stranger's list does not
+     * merely miss ours - it collides with a few of them, and `parseDevices()` matches on
+     * `uid` and type alone. That is how a light of ours picks up somebody else's on/off.
+     *
+     * Measured against a live household over a day: this account's own page names all but one
+     * of the devices it lists in the configuration, while the pages of strangers name at most a
+     * fifth of theirs. A majority sits between the two with room to spare on both sides.
+     */
+    private isOwnHouseholdDeviceList(deviceList: any[]): boolean {
+        const configured = new Set((this.config.devices || []).map((device) => device.deviceId));
+        // Nothing to hold the list against.
+        // The settings wizard signs in precisely to find out what this household has,
+        // and the resident then reads that list on screen and saves it -
+        // which is the confirmation this judgement would otherwise be standing in for.
+        if(configured.size === 0) {
+            if(!this.reportedUncomparableDeviceList) {
+                this.reportedUncomparableDeviceList = true;
+                this.log.debug("Nothing configured to hold a device list against; " +
+                    "accepting it as this household's.");
+            }
+            return true;
+        }
+        let listed = 0;
+        let ours = 0;
+        for(const deviceGroup of deviceList) {
+            for(const device of deviceGroup?.["devices"] || []) {
+                const deviceId = device?.["uid"];
+                if(typeof deviceId !== "string" || deviceId.trim().length === 0) {
+                    continue;
+                }
+                listed += 1;
+                if(configured.has(deviceId)) {
+                    ours += 1;
+                }
+            }
+        }
+        // A list that named nobody carries no state to mistake for ours,
+        // so there is nothing to protect against and something to lose by refusing:
+        // a household part-way through setup would never get past this.
+        if(listed === 0) {
+            return true;
+        }
+        return ours * 2 > listed;
+    }
+
+    /**
+     * Device types worth asking the WallPad about.
+     *
+     * What the last accepted page carried, where there has been one - that is the server's own
+     * account of which types it answers for. Before then the configuration stands in, because
+     * the first page after a sign-in is sometimes the one that gets declined, and a start that
+     * declines its first page would otherwise ask about nothing at all and sit blind until a
+     * page happens to come back ours. A type the query cannot answer for costs one entry in a
+     * JSON array and is ignored.
+     */
+    private deviceTypesToAskAbout(): DeviceType[] {
+        if(this.renderedDeviceTypes.length > 0) {
+            return this.renderedDeviceTypes;
+        }
+        return [...new Set((this.config.devices || []).map((device) => device.deviceType))];
+    }
+
+    /**
+     * Asks the WallPad for the state of whole device types,
+     * the same query the app's own pages run when they open.
+     * The answer arrives through the usual listeners, marked as a complete snapshot.
+     *
+     * This is what a declined page falls back on. The rendered page is the only thing
+     * the server gets wrong; the socket answers for the session.
+     */
+    async requestDeviceStatus(deviceTypes: DeviceType[] = this.deviceTypesToAskAbout()) {
+        if(!this.ws || deviceTypes.length === 0) {
+            return;
+        }
+        await this.sendJson({
+            "roomKey": this.wsCredentials?.roomKey,
+            "userKey": this.wsCredentials?.userKey,
+            "accessToken": this.wsCredentials?.accessToken,
+            "data": deviceTypes.map((deviceType) => ({ type: deviceType.toString() })),
+        });
     }
 
     private async refreshDeviceStatus(forceFetch: boolean = false) {
         if(!this.ws) {
             return;
         }
-        const deviceList: any[] = parseDeviceList(await this.fetchServerSideRenderedHTML(forceFetch));
+        const page = await this.fetchRenderedPage(forceFetch);
+        if(!page.ownHousehold || !page.deviceList) {
+            // Nothing of this page reaches the accessories, and none of it is echoed back
+            // to the socket either - asking the server about a stranger's devices is how
+            // their answers came back as ours. The WallPad is asked instead, so that
+            // declining a page costs freshness rather than sight.
+            await this.requestDeviceStatus();
+            return;
+        }
+        const deviceList = page.deviceList;
         await this.sendJson({
             "roomKey": this.wsCredentials?.roomKey,
             "userKey": this.wsCredentials?.userKey,
@@ -911,7 +1073,18 @@ export default class SmartELifeClient {
     }
 
     async fetchDevices(): Promise<Device[]> {
-        const deviceList: any[] = parseDeviceList(await this.fetchServerSideRenderedHTML());
+        const page = await this.fetchRenderedPage();
+        if(!page.ownHousehold || !page.deviceList) {
+            // A wizard signing in for the first time has nothing to hold a page against,
+            // so it never reaches this - the judgement is skipped and the resident reads
+            // the list on screen instead. Getting here means a saved configuration exists
+            // and the page did not match it, which is worth saying rather than answering
+            // with an empty household.
+            this.log.warn("The rendered device list was not this household's, so no devices were read. " +
+                "Try again in a moment.");
+            return [];
+        }
+        const deviceList = page.deviceList;
         const fetchedDevices: Device[] = [];
         for(const deviceGroup of deviceList) {
             const deviceType = deviceGroup["type"] as DeviceType || DeviceType.UNKNOWN;

--- a/core/smart-elife/smart-elife-client.ts
+++ b/core/smart-elife/smart-elife-client.ts
@@ -41,6 +41,11 @@ export interface ListenerMetadata {
      * Commands draw from the same counter,
      * so a report numbered below a command cannot say anything about that command -
      * the poll it came from was already in the air when the command was sent.
+     *
+     * Where "requested" is, per path: a polled page draws its number before the HTTP
+     * request leaves; the answer to a WebSocket status query wears the number drawn
+     * when that query was sent (`sendStatusQuery`); an asynchronous `event_*` push is
+     * never requested, so its number is drawn at frame receipt.
      */
     observedSeq: number
 
@@ -167,6 +172,14 @@ export default class SmartELifeClient {
      */
     private renderedDeviceTypes: DeviceType[] = [];
 
+    /**
+     * Numbers drawn for status queries whose answers have not arrived yet, per type.
+     * FIFO: the socket answers queries of one type in the order they were sent,
+     * so the head of the queue always belongs to the next answer.
+     * Cleared on reconnect - see `onOpen`.
+     */
+    private readonly pendingStatusQueries = new Map<DeviceType, number[]>();
+
     /** How many reports were declined as another household's, for the debug log. */
     private declinedForeignReports = 0;
 
@@ -213,11 +226,15 @@ export default class SmartELifeClient {
                 return ClientResponseCode.SUCCESS;
             },
             async onOpen(client: SmartELifeClient) {
+                // Queries in flight on the previous connection will never be answered here,
+                // and their numbers must not attach to this connection's answers.
+                client.pendingStatusQueries.clear();
                 await client.requestElevatorStatus();
             },
             async onMessage(client: SmartELifeClient, json: any) {
-                // Stamped where the frame is received. Everything below is parsing.
-                const observedSeq = client.takeObservedSeq();
+                // Stamped where the frame is received - the fallback for everything
+                // that is not the answer to a query this client sent.
+                let observedSeq = client.takeObservedSeq();
                 const observedAt = Date.now();
 
                 const header = json["header"];
@@ -253,6 +270,18 @@ export default class SmartELifeClient {
                 const deviceType = deviceTypeString as DeviceType || DeviceType.UNKNOWN;
                 if(deviceType === DeviceType.UNKNOWN)
                     client.log.warn("Unknown device type: %s", deviceTypeString);
+
+                if(completeSnapshot) {
+                    // The answer to a query wears the number drawn when that query left,
+                    // not the receive stamp - a command sent while the query was in flight
+                    // must rank above the answer, or a stale report slips past the filters
+                    // built on this ordering. Consumed even when the frame is declined
+                    // below, so the per-type FIFO stays aligned with the answers.
+                    const queued = client.pendingStatusQueries.get(deviceType)?.shift();
+                    if(queued !== undefined) {
+                        observedSeq = queued;
+                    }
+                }
 
                 // The socket carries the same misattribution the rendered page does.
                 // A day of measurement found 91 answers that listed another household's devices.
@@ -1165,11 +1194,28 @@ export default class SmartELifeClient {
         if(!this.ws || deviceTypes.length === 0) {
             return;
         }
+        await this.sendStatusQuery(
+            deviceTypes.map((deviceType) => ({ type: deviceType.toString() })),
+            deviceTypes);
+    }
+
+    /**
+     * Sends a status query and records, per device type, the number drawn as it leaves.
+     * The answers arrive through `onMessage` as complete snapshots and pick these numbers
+     * back up in order - see `ListenerMetadata.observedSeq` for why the send is the moment
+     * that counts.
+     */
+    private async sendStatusQuery(data: any[], deviceTypes: DeviceType[]) {
+        for(const deviceType of deviceTypes) {
+            const queue = this.pendingStatusQueries.get(deviceType) || [];
+            queue.push(this.takeObservedSeq());
+            this.pendingStatusQueries.set(deviceType, queue);
+        }
         await this.sendJson({
             "roomKey": this.wsCredentials?.roomKey,
             "userKey": this.wsCredentials?.userKey,
             "accessToken": this.wsCredentials?.accessToken,
-            "data": deviceTypes.map((deviceType) => ({ type: deviceType.toString() })),
+            "data": data,
         });
     }
 
@@ -1189,12 +1235,9 @@ export default class SmartELifeClient {
             return;
         }
         const deviceList = page.deviceList;
-        await this.sendJson({
-            "roomKey": this.wsCredentials?.roomKey,
-            "userKey": this.wsCredentials?.userKey,
-            "accessToken": this.wsCredentials?.accessToken,
-            "data": deviceList,
-        });
+        await this.sendStatusQuery(deviceList, deviceList
+            .map((deviceGroup: any) => deviceGroup["type"] as DeviceType)
+            .filter((deviceType: DeviceType) => !!deviceType));
 
         for(const deviceGroup of deviceList) {
             const deviceType = deviceGroup["type"] as DeviceType || DeviceType.UNKNOWN;

--- a/core/smart-elife/ws-scheduler.ts
+++ b/core/smart-elife/ws-scheduler.ts
@@ -21,6 +21,8 @@ export default class WebSocketScheduler {
     private wsClosedByUser: boolean = false;
     private wsLastAuthRefreshAtMs: number = 0;
     private wsConnectPromise?: Promise<void>;
+    /** Non-JSON frames discarded on the current connection, for log rate-limiting. */
+    private wsNonJsonFrames: number = 0;
 
     constructor(
         private readonly client: SmartELifeClient,
@@ -97,6 +99,17 @@ export default class WebSocketScheduler {
         }
         // ArrayBuffer
         return Buffer.from(data).toString("utf8");
+    }
+
+    private static wsRawDataByteLength(data: WebSocket.RawData): number {
+        if(Buffer.isBuffer(data)) {
+            return data.length;
+        }
+        if(Array.isArray(data)) {
+            return data.reduce((total, chunk) => total + chunk.length, 0);
+        }
+        // ArrayBuffer
+        return data.byteLength;
     }
 
     private async waitForWebSocketOpen(ws: WebSocket, timeoutMs: number = 10_000): Promise<void> {
@@ -242,9 +255,16 @@ export default class WebSocketScheduler {
                 const ws = new WebSocket(url, {
                     headers,
                     perMessageDeflate: false,
+                    // Real frames are kilobytes (a type's whole device snapshot, an
+                    // elevator action); the library default of 100 MiB would let one
+                    // hostile or broken frame balloon into a string that size before
+                    // any handler sees it. An oversized frame closes with 1009 and
+                    // the reconnect path takes over.
+                    maxPayload: 1024 * 1024,
                 } as any);
                 this.ws = ws;
                 this.wsClosedByUser = false;
+                this.wsNonJsonFrames = 0;
 
                 ws.on("open", () => {
                     this.wsReconnectAttempt = 0;
@@ -273,7 +293,29 @@ export default class WebSocketScheduler {
                         return;
                     }
 
-                    const json = Utils.parseJsonSafe(text);
+                    let json;
+                    try {
+                        json = Utils.parseJsonSafe(text);
+                    } catch {
+                        // This handler is async; a throw here would surface as an
+                        // unhandled rejection rather than anything catchable.
+                        // warn shows without debug mode, so it carries an escaped,
+                        // bounded preview and fires once per connection; the full
+                        // frame goes to debug like every other body this file logs,
+                        // escaped so it stays one line. `maxPayload` above bounds
+                        // the size either way.
+                        this.wsNonJsonFrames += 1;
+                        if(this.wsNonJsonFrames === 1) {
+                            // Sized from the raw frame, before any decoding - a decoded
+                            // string misreports trimmed whitespace and invalid UTF-8.
+                            const wireBytes = WebSocketScheduler.wsRawDataByteLength(data);
+                            this.log.warn(`[WebSocket] discarded a frame that is not JSON: `
+                                + `${wireBytes} byte(s), ${JSON.stringify(text.slice(0, 160))}`);
+                        }
+                        this.log.debug(`[WebSocket] discarded a frame that is not JSON `
+                            + `(${this.wsNonJsonFrames} so far): ${JSON.stringify(text)}`);
+                        return;
+                    }
                     this.log.debug(`[WebSocket] message (JSON): ${JSON.stringify(json)}`);
                     this.injector.onMessage(this.client, json);
                 });

--- a/core/smart-elife/ws-scheduler.ts
+++ b/core/smart-elife/ws-scheduler.ts
@@ -128,21 +128,35 @@ export default class WebSocketScheduler {
         });
     }
 
-    public async wsSendJson(payload: any): Promise<void> {
+    /**
+     * Returns whether the socket accepted the frame. The drop paths used to be
+     * silent, which left callers unable to tell a sent query from a discarded one -
+     * and the status-query FIFO records an entry per sent query,
+     * so a discard mistaken for a send misaligns every answer after it.
+     *
+     * `beforeSend` runs synchronously as the frame is handed to the socket - after any
+     * reconnect this call rode through, in the same turn as the send itself. That is
+     * the only moment a caller can record bookkeeping that must exist before the
+     * answer can possibly arrive and must not exist if the frame is never attempted:
+     * the answer to a frame can be dispatched before the frame's own send callback
+     * when the event loop was busy across the round trip.
+     */
+    public async wsSendJson(payload: any, beforeSend?: () => void): Promise<boolean> {
         try {
             await this.connectWebSocket();
             const ws = this.ws;
             if(!ws) {
-                return;
+                return false;
             }
             await this.waitForWebSocketOpen(ws, 10_000);
             if(ws.readyState !== WebSocket.OPEN) {
                 this.scheduleWebSocketReconnect("send while not open");
-                return;
+                return false;
             }
 
             await new Promise<void>((resolve, reject) => {
                 this.log.debug(`[WebSocket] :: Send :: ${JSON.stringify(payload)}`);
+                beforeSend?.();
                 ws.send(JSON.stringify(payload), (err?: Error) => {
                     if(err) {
                         reject(err);
@@ -151,11 +165,12 @@ export default class WebSocketScheduler {
                     }
                 });
             });
+            return true;
         } catch (err) {
             if(this.isSocketClosedDuringSendError(err)) {
                 this.log.warn(`[WebSocket] send skipped due to socket close race: ${(err as any)?.message || err}`);
                 this.scheduleWebSocketReconnect("send on closed socket");
-                return;
+                return false;
             }
             throw err;
         }
@@ -209,9 +224,17 @@ export default class WebSocketScheduler {
                 const url = this.getWebSocketUrl();
                 const headers = this.getWebSocketHeaders();
 
-                // Close any previous instance (best-effort) before replacing.
+                // Close any previous instance (best-effort) before replacing. Its frames
+                // must not reach handlers that now describe the new connection - a late
+                // answer would consume the new FIFO's head - and its close must not
+                // schedule a reconnect over the connect in progress. `error` and `open`
+                // stay attached, so a late socket error cannot crash as an unhandled
+                // 'error' event.
+                const previous = this.ws;
+                previous?.removeAllListeners("message");
+                previous?.removeAllListeners("close");
                 try {
-                    this.ws?.close();
+                    previous?.close();
                 } catch {
                     // ignore
                 }

--- a/homebridge-ui/providers/smart-elife.ts
+++ b/homebridge-ui/providers/smart-elife.ts
@@ -1,7 +1,7 @@
 import AbstractUiProvider from "./ui-provider";
 import {HomebridgePluginUiServer} from "@homebridge/plugin-ui-utils";
 import {LoggerBase, Semaphore, Utils} from "../../core/utils";
-import SmartELifeClient from "../../core/smart-elife/smart-elife-client";
+import SmartELifeClient, {HouseholdAttribution} from "../../core/smart-elife/smart-elife-client";
 import {Device, DeviceType, SmartELifeConfig} from "../../core/interfaces/smart-elife-config";
 import {ClientResponseCode} from "../../core/smart-elife/responses";
 import {Logging} from "homebridge";
@@ -24,6 +24,8 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
 
     private devices: Device[] = [];
     private devicesFetched: boolean = false;
+    /** How the last kept list was attributed, replayed with the cache. */
+    private household: HouseholdAttribution = HouseholdAttribution.UNKNOWN;
 
     constructor(server: HomebridgePluginUiServer, log: LoggerBase | Logging) {
         super(server, log);
@@ -49,9 +51,13 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
     }
 
     async onRequestDevices(p: any) {
-        if(this.devicesFetched && this.devices) {
+        // `force` bypasses the cache. The frontend's re-fetch button needs it -
+        // without it, reopening the settings replays whatever this process fetched first,
+        // and the only way to actually query again was a full reset.
+        if(!p?.force && this.devicesFetched && this.devices) {
             this.server.pushEvent("devices-fetched", {
                 devices: this.devices,
+                household: this.household,
             });
         } else {
             await this.signIn(p);
@@ -85,7 +91,10 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
             username, password, uuid,
             wallpadVersion: WALLPAD_VERSION_3_0,
             version: Utils.currentSemanticVersion(),
-            devices: this.devices,
+            // The saved list the frontend sent along is the yardstick the client holds
+            // rendered pages against. Without it every page passes as UNKNOWN -
+            // the first sign-in of this process has no cache to fall back on.
+            devices: Array.isArray(p.devices) ? p.devices : this.devices,
         };
         this.client = SmartELifeClient.createForUI(this.log, config);
 
@@ -127,20 +136,31 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
         const version = await this.client.parseWallPadVersion();
 
         // Set up devices
-        const { devices: fetchedDevices } = await this.client.fetchDevices();
+        const result = await this.client.fetchDevices();
+        if(result.household === HouseholdAttribution.FOREIGN
+            || result.household === HouseholdAttribution.INVALID) {
+            // The cache is left alone - a failed refresh must not become the list the next
+            // request replays. `complete` still goes out: the session credentials are this
+            // household's regardless of whose device list the page carried (measured),
+            // and the runtime cannot start without them.
+            this.server.pushEvent("device-refresh-failed", { reason: result.household });
+            this.server.pushEvent("complete", { uuid, roomKey, userKey, version });
+            return;
+        }
 
         const devices = await this.configureInitialDevices();
-        for(const device of fetchedDevices) {
+        for(const device of result.devices) {
             devices.push(device);
         }
         this.devices = devices;
         this.devicesFetched = true;
+        this.household = result.household;
 
         // On success
         // `devices-fetched` is pushed before `complete`,
         // so that a pane waiting only for the device list settles before the wizard moves on.
         // Without it, a sign-in triggered by `/fetch-devices` would report nothing the caller listens for.
-        this.server.pushEvent("devices-fetched", { devices });
+        this.server.pushEvent("devices-fetched", { devices, household: result.household });
         this.server.pushEvent("complete", { uuid, roomKey, userKey, version });
     }
 

--- a/homebridge-ui/providers/smart-elife.ts
+++ b/homebridge-ui/providers/smart-elife.ts
@@ -26,6 +26,8 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
     private devicesFetched: boolean = false;
     /** How the last kept list was attributed, replayed with the cache. */
     private household: HouseholdAttribution = HouseholdAttribution.UNKNOWN;
+    /** The resident's own room names from the last kept fetch, replayed with the cache. */
+    private aliases: Record<string, string> = {};
 
     constructor(server: HomebridgePluginUiServer, log: LoggerBase | Logging) {
         super(server, log);
@@ -58,6 +60,7 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
             this.server.pushEvent("devices-fetched", {
                 devices: this.devices,
                 household: this.household,
+                aliases: this.aliases,
             });
         } else {
             await this.signIn(p);
@@ -155,12 +158,14 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
         this.devices = devices;
         this.devicesFetched = true;
         this.household = result.household;
+        this.aliases = result.aliases;
 
         // On success
         // `devices-fetched` is pushed before `complete`,
         // so that a pane waiting only for the device list settles before the wizard moves on.
         // Without it, a sign-in triggered by `/fetch-devices` would report nothing the caller listens for.
-        this.server.pushEvent("devices-fetched", { devices, household: result.household });
+        this.server.pushEvent("devices-fetched",
+            { devices, household: result.household, aliases: result.aliases });
         this.server.pushEvent("complete", { uuid, roomKey, userKey, version });
     }
 

--- a/homebridge-ui/providers/smart-elife.ts
+++ b/homebridge-ui/providers/smart-elife.ts
@@ -69,6 +69,13 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
 
     async invalidate(_: any) {
         this.client = undefined;
+        // A reset ends the session the cache belongs to. Without this, the first
+        // force-less fetch after a re-login would replay the previous session's list,
+        // because a sign-in refused as FOREIGN/INVALID deliberately leaves the cache alone.
+        this.devices = [];
+        this.devicesFetched = false;
+        this.household = HouseholdAttribution.UNKNOWN;
+        this.aliases = {};
     }
 
     async signIn(p: any) {

--- a/homebridge-ui/providers/smart-elife.ts
+++ b/homebridge-ui/providers/smart-elife.ts
@@ -127,7 +127,7 @@ export default class SmartELifeUiServer extends AbstractUiProvider {
         const version = await this.client.parseWallPadVersion();
 
         // Set up devices
-        const fetchedDevices = await this.client.fetchDevices();
+        const { devices: fetchedDevices } = await this.client.fetchDevices();
 
         const devices = await this.configureInitialDevices();
         for(const device of fetchedDevices) {

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -724,6 +724,8 @@ class WallpadPasscodePane extends Pane {
 const DEVICE_REFRESH_FAILED_MESSAGE = "기기 목록을 갱신하지 못했습니다. 저장된 목록으로 설정을 편집합니다.";
 const WALLPAD_REAUTHORIZATION_MESSAGE = "월패드 재인증이 필요합니다. 기기 목록을 갱신하려면 '재설정'으로 다시 로그인해주세요.";
 const DEVICE_REFRESH_KEPT_MESSAGE = "기기 목록을 조회하지 못했습니다. 저장된 설정은 그대로 유지됩니다.";
+const DEVICE_SAVE_FAILED_MESSAGE = "기기 목록을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.";
+const SETTINGS_SAVE_FAILED_MESSAGE = "설정을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.";
 
 const DEVICE_TYPE_LABELS = {
     "light": "조명",
@@ -750,81 +752,86 @@ function escapeHtml(text) {
         .replace(/"/g, "&quot;");
 }
 
-class CompletePane extends Pane {
-    constructor(element, config) {
+function devicesEquals(provider, oldDevice, newDevice) {
+    if(provider === "daelim") {
+        return oldDevice.name === newDevice.name
+            && oldDevice.deviceId === newDevice.deviceId
+            && oldDevice.deviceType === newDevice.deviceType;
+    } else {
+        return oldDevice.deviceType === newDevice.deviceType
+            && oldDevice.name === newDevice.name
+            && oldDevice.deviceId === newDevice.deviceId;
+    }
+}
+
+// Merges a fetched device list against the saved one, keeping the saved entry
+// (with its display name and disabled flag) wherever the device is already known,
+// and says what saving the merge would add and take away.
+function mergeFetchedDevices(provider, savedDevices, fetchedDevices) {
+    const availableDevices = [];
+    for(const device of fetchedDevices) {
+        const equiv = savedDevices
+            .filter(oldDevice => devicesEquals(provider, oldDevice, device));
+        if(!equiv || !equiv.length) {
+            availableDevices.push(device);
+        } else {
+            availableDevices.push(equiv[0]);
+        }
+    }
+    const added = fetchedDevices.filter(device =>
+        !savedDevices.some(oldDevice => devicesEquals(provider, oldDevice, device)));
+    const removed = savedDevices.filter(oldDevice =>
+        !availableDevices.some(device => devicesEquals(provider, oldDevice, device)));
+    return { availableDevices, added, removed };
+}
+
+/**
+ * The device-list confirmation procedure, on its own pane.
+ *
+ * Nothing is saved while this pane is showing. The fetched list is a candidate until
+ * the resident presses '확인하고 저장' - that press is the confirmation the household
+ * judgement stands on ever after - and '다시 조회' asks the server again, which signs
+ * in anew and reads the page right after, the most reliable moment there is (#198).
+ *
+ * Shown by CompletePane in one of three modes: "first" (a first-time setup showing
+ * the whole fetched list), "first-failed" (a first-time setup whose fetch failed,
+ * with retry as the only way forward), and "diff" (an existing configuration whose
+ * re-fetch differs from the saved list, on the way into the advanced editor).
+ */
+class DeviceConfirmPane extends Pane {
+    constructor(element, config, payload) {
         super(element, config);
 
-        // Device data still arrives through an event for compatibility, while each
-        // provider request now has its own terminal success or failure.
-        this._settled = false;
-        this._refreshed = false;
-        this._advancedFormOpened = false;
-
-        // What the last fetch reported, held until the resident explicitly saves it.
-        // The config keeps its saved list all the while - that list is also the yardstick
-        // the server judges fetched pages against, so replacing it must be a decision.
-        this._pendingDevices = null;
-        this._pendingAdded = [];
-        this._pendingRemoved = [];
+        this._mode = payload.mode;
+        this._devices = payload.devices || [];
+        this._added = payload.added || [];
+        this._removed = payload.removed || [];
         // Display-only: the resident's own room names, keyed by device id.
-        this._pendingAliases = {};
-        // Which confirmation screen is showing: "first", "first-failed", "diff", or null.
-        this._confirmMode = null;
+        this._aliases = payload.aliases || {};
+        // Whether the last re-fetch request produced any terminal event;
+        // a request that resolves without one gave up quietly and counts as a failure.
+        this._answered = false;
+        // One operation at a time. Refetching while a save is committing (or the other
+        // way around) would let two paths advance() off this pane, or let a disposed
+        // pane mistake its still-running refetch for a quiet failure.
+        this._busy = false;
+        // Latched once a transition off this pane has started. The refetch request can
+        // settle while the devices-fetched handler is still mid-advance() - the event
+        // emitter does not await its handlers - and the click handler's finally must
+        // not re-enable the departing screen's buttons in that gap.
+        this._advancing = false;
 
         this.pane = document.createElement("div");
         this.pane.classList.add("hidden");
-        this.pane.id = "done";
-        this.pane.innerHTML = `
-            <div class="text-center" id="done-main">
-                <h2>설정이 완료되었습니다.</h2>
-                <p>이제 <span class="brand-name">DL E&C</span> 아파트의 가구를 애플 기기에서 제어할 수 있습니다.</p>
-                <button type="button" id="advanced-button" class="btn btn-secondary" disabled>고급</button>
-                <button type="button" id="reset-button" class="btn btn-primary">재설정</button>
-                <button type="button" id="done-button" class="btn btn-primary">닫기</button>
-            </div>
-            <div class="hidden" id="device-confirm"></div>
-        `;
-        this.doneMain = this.pane.querySelector("#done-main");
-        this.confirmContainer = this.pane.querySelector("#device-confirm");
-        this.advancedButton = this.pane.querySelector("#advanced-button");
-        this.resetButton = this.pane.querySelector("#reset-button");
-        this.doneButton = this.pane.querySelector("#done-button");
+        this.pane.id = "device-confirm";
+    }
+
+    canPassthrough() {
+        return false;
     }
 
     selfPane() {
         return this.pane;
-    }
-
-    canPassthrough() {
-        // this is the EOP (end-of-pane)
-        return false;
-    }
-
-    nextPane() {
-        return new ResetConfirmablePane(this.element, this.config);
-    }
-
-    _settle(warning) {
-        if(this._settled) {
-            return; // only the first terminal state wins
-        }
-        this._settled = true;
-        this.advancedButton.removeAttribute("disabled");
-        if(warning) {
-            window.homebridge.toast.warning(warning);
-        }
-    }
-
-    devicesEquals(oldDevice, newDevice) {
-        if(this.config.provider === "daelim") {
-            return oldDevice.name === newDevice.name
-                && oldDevice.deviceId === newDevice.deviceId
-                && oldDevice.deviceType === newDevice.deviceType;
-        } else {
-            return oldDevice.deviceType === newDevice.deviceType
-                && oldDevice.name === newDevice.name
-                && oldDevice.deviceId === newDevice.deviceId;
-        }
     }
 
     _deviceRow(device, badge) {
@@ -838,7 +845,7 @@ class CompletePane extends Pane {
         // The side slot names the room the device is in - the name the resident
         // gave it where there is one, the canonical name otherwise, and nothing
         // where the page carried neither.
-        const aside = this._pendingAliases[device.deviceId] || "";
+        const aside = this._aliases[device.deviceId] || "";
         return `<li class="list-group-item d-flex justify-content-between align-items-center py-1 px-3">
             <span${strike}>${escapeHtml(displayName)}${label}</span>
             <small style="opacity: .65;">${escapeHtml(aside)}</small>
@@ -874,8 +881,8 @@ class CompletePane extends Pane {
         return rows.join("");
     }
 
-    _confirmScreenHtml() {
-        if(this._confirmMode === "first-failed") {
+    _screenHtml() {
+        if(this._mode === "first-failed") {
             return `
                 <div class="text-center">
                     <h2>기기 목록을 조회하지 못했습니다.</h2>
@@ -884,14 +891,14 @@ class CompletePane extends Pane {
                 </div>
             `;
         }
-        if(this._confirmMode === "first") {
+        if(this._mode === "first") {
             return `
                 <div class="text-center">
                     <h2>기기 목록을 확인해주세요.</h2>
-                    <p>${this._pendingDevices.length}개의 기기가 조회되었습니다. 아래 목록이 맞는지 확인해주세요.</p>
+                    <p>${this._devices.length}개의 기기가 조회되었습니다. 아래 목록이 맞는지 확인해주세요.</p>
                 </div>
                 <ul class="list-group mb-3 text-left" style="max-height: 220px; overflow-y: auto; font-size: 14px;">
-                    ${this._deviceListRows(this._pendingDevices)}
+                    ${this._deviceListRows(this._devices)}
                 </ul>
                 <div class="text-center">
                     <button type="button" id="refetch-button" class="btn btn-secondary">다시 조회</button>
@@ -900,12 +907,12 @@ class CompletePane extends Pane {
             `;
         }
         // "diff": what an explicit save would add and take away, against the saved list.
-        const keptCount = this._pendingDevices.length - this._pendingAdded.length;
+        const keptCount = this._devices.length - this._added.length;
         const rows = [this._deviceGroupHeader("변경")];
-        for(const device of this._pendingAdded) {
+        for(const device of this._added) {
             rows.push(this._deviceRow(device, "added"));
         }
-        for(const device of this._pendingRemoved) {
+        for(const device of this._removed) {
             rows.push(this._deviceRow(device, "removed"));
         }
         rows.push(`<li class="list-group-item py-1 px-3 text-center">
@@ -927,53 +934,280 @@ class CompletePane extends Pane {
         `;
     }
 
-    _showConfirm(mode) {
-        this._confirmMode = mode;
-        this.confirmContainer.innerHTML = this._confirmScreenHtml();
-        this.doneMain.classList.add("hidden");
-        this.confirmContainer.classList.remove("hidden");
+    _render() {
+        this.pane.innerHTML = this._screenHtml();
+    }
 
-        const refetchButton = this.confirmContainer.querySelector("#refetch-button");
-        if(refetchButton) {
-            this.addListener(refetchButton, "click", async () => {
-                refetchButton.disabled = true;
-                await this._requestRefresh(true);
-                refetchButton.disabled = false;
+    _setButtonsDisabled(disabled) {
+        for(const button of this.pane.querySelectorAll("button")) {
+            button.disabled = disabled;
+        }
+    }
+
+    async _refetch() {
+        window.homebridge.showSpinner();
+        this._answered = false;
+        try {
+            await window.homebridge.request(`/${this.config.provider}/fetch-devices`, {
+                region: this.config.region,
+                complex: this.config.complex,
+                username: this.config.username,
+                password: this.config.password,
+                // The saved device list rides along as the yardstick the server holds
+                // fetched pages against. Empty on a first-time setup.
+                devices: this.config.devices || [],
+                force: true,
             });
+        } catch(error) {
+            console.error("Refreshing devices failed:", error);
+        } finally {
+            window.homebridge.hideSpinner();
         }
-        const confirmButton = this.confirmContainer.querySelector("#confirm-save-button");
-        if(confirmButton) {
-            this.addListener(confirmButton, "click", async () => {
-                confirmButton.disabled = true;
-                await this._confirmSave();
-            });
-        }
-    }
-
-    _showDone() {
-        this._confirmMode = null;
-        this.confirmContainer.classList.add("hidden");
-        this.confirmContainer.innerHTML = "";
-        this.doneMain.classList.remove("hidden");
-    }
-
-    async _confirmSave() {
-        const mode = this._confirmMode;
-        this.config.devices = this._pendingDevices;
-        await this.updatePluginConfig();
-        await this.savePluginConfig();
-        this._pendingDevices = null;
-        this._pendingAdded = [];
-        this._pendingRemoved = [];
-        this._showDone();
-        this._settle();
-        if(mode === "diff") {
-            // The resident was on their way to the editor - continue there.
-            await this._openAdvancedForm();
+        if(!this._answered) {
+            this._onRefetchFailed();
         }
     }
 
-    async _requestRefresh(force) {
+    _onRefetchFailed() {
+        this._answered = true;
+        if(this._mode === "first-failed") {
+            // Still nothing to show; the screen already says so.
+            this._render();
+            return;
+        }
+        // The candidate on screen is left exactly as it was.
+        window.homebridge.toast.warning(DEVICE_REFRESH_KEPT_MESSAGE);
+    }
+
+    // A failed step must hand the screen back - without this, a refused save or a
+    // failed transition leaves `_advancing` latched and the pane dead until the
+    // settings are reopened.
+    _recoverFromFailure() {
+        this._advancing = false;
+        this._busy = false;
+        this._setButtonsDisabled(false);
+    }
+
+    async _save() {
+        const mode = this._mode;
+        const savedDevices = this.config.devices;
+        this._advancing = true;
+        try {
+            this.config.devices = this._devices;
+            await this.updatePluginConfig();
+            await this.savePluginConfig();
+        } catch(error) {
+            console.error("Saving the device list failed:", error);
+            // Nothing was persisted; the saved list stays the yardstick.
+            this.config.devices = savedDevices;
+            try {
+                await this.updatePluginConfig();
+            } catch {
+                // The next update rewrites the whole config block anyway.
+            }
+            window.homebridge.toast.warning(DEVICE_SAVE_FAILED_MESSAGE);
+            this._recoverFromFailure();
+            return;
+        }
+        try {
+            await this.advance({}, new CompletePane(this.element, this.config, {
+                // The resident was on their way to the editor - continue there.
+                openAdvanced: mode === "diff",
+            }));
+        } catch(error) {
+            // The list is saved; only the screen failed to move on.
+            console.error("Leaving the confirmation screen failed:", error);
+            this._recoverFromFailure();
+        }
+    }
+
+    register() {
+        this.ensureAttached();
+        refreshTrademark(this.config);
+        this._render();
+
+        // One delegated listener survives every re-render;
+        // wiring the buttons anew per render would pile up dead handler bookkeeping.
+        // While either operation runs, BOTH buttons are disabled - '확인하고 저장'
+        // during a refetch (or the reverse) would race two advance() paths.
+        this.addListener(this.pane, "click", async (event) => {
+            const button = event.target.closest("button");
+            if(!button || button.disabled || this._busy) {
+                return;
+            }
+            this._busy = true;
+            this._setButtonsDisabled(true);
+            try {
+                if(button.id === "refetch-button") {
+                    await this._refetch();
+                } else if(button.id === "confirm-save-button") {
+                    await this._save();
+                }
+            } finally {
+                // Once a transition has started this pane is on its way out, and its
+                // buttons stay dead - the request may settle before the handler that
+                // is advancing off this pane does.
+                if(!this._advancing) {
+                    this._busy = false;
+                    // A refetch re-rendered fresh (enabled) buttons; re-enabling
+                    // covers the failure paths that kept the old screen.
+                    this._setButtonsDisabled(false);
+                }
+            }
+        });
+
+        this.addHomebridgeListener("devices-fetched", async (event) => {
+            this._answered = true;
+            if(this._advancing) {
+                // Already leaving this pane; a late list must not redraw it
+                // or start a second transition.
+                return;
+            }
+            const {availableDevices, added, removed} = mergeFetchedDevices(
+                this.config.provider, this.config.devices || [], event["data"].devices);
+            this._aliases = event["data"].aliases || {};
+
+            if((this.config.devices || []).length === 0) {
+                // First-time setup: the list itself is the screen.
+                this._mode = "first";
+                this._devices = availableDevices;
+                this._added = added;
+                this._removed = removed;
+                this._render();
+                return;
+            }
+            if(added.length === 0 && removed.length === 0) {
+                // The re-fetch converged with the saved list - saving would be a no-op,
+                // so there is nothing left to confirm. Continue to the editor the
+                // resident was headed for.
+                this._advancing = true;
+                try {
+                    await this.advance({}, new CompletePane(this.element, this.config, {
+                        openAdvanced: this._mode === "diff",
+                    }));
+                } catch(error) {
+                    console.error("Leaving the confirmation screen failed:", error);
+                    this._recoverFromFailure();
+                }
+                return;
+            }
+            // A re-fetch changed the picture - redraw it against the saved list.
+            this._mode = "diff";
+            this._devices = availableDevices;
+            this._added = added;
+            this._removed = removed;
+            this._render();
+        });
+        this.addHomebridgeListener("device-refresh-failed", () => {
+            this._onRefetchFailed();
+        });
+        this.addHomebridgeListener("authorization-failed", () => {
+            this._answered = true;
+            window.homebridge.toast.warning(DEVICE_REFRESH_FAILED_MESSAGE);
+        });
+        this.addHomebridgeListener("require-wallpad-passcode", () => {
+            this._answered = true;
+            window.homebridge.toast.warning(WALLPAD_REAUTHORIZATION_MESSAGE);
+        });
+    }
+}
+
+class CompletePane extends Pane {
+    constructor(element, config, options) {
+        super(element, config);
+
+        // Device data still arrives through an event for compatibility, while each
+        // provider request now has its own terminal success or failure.
+        this._settled = false;
+        // Not the same thing as `_settled`: a failed refresh for an existing
+        // configuration reaches its terminal state with the editor deliberately
+        // locked - the fetched list it would edit does not exist. Only `_settle()`
+        // unlocks, and failure recovery restores buttons from this flag, not from
+        // `_settled`.
+        this._advancedUnlocked = false;
+        this._refreshed = false;
+        this._advancedFormOpened = false;
+
+        // What the last fetch reported where it differs from the saved list, held for
+        // the confirmation pane the advanced button hands it to. The config keeps its
+        // saved list all the while - that list is also the yardstick the server judges
+        // fetched pages against, so replacing it must be a decision, and the decision
+        // belongs to DeviceConfirmPane.
+        this._pendingFetch = null;
+        // Set when the confirmation pane sends the resident onward to the editor.
+        this._openAdvancedOnRegister = !!(options && options.openAdvanced);
+        // Single-flight latch for every way off this pane. advance() awaits the
+        // config update, and a second press in that window would register a second
+        // pane - duplicate DOM, duplicate Homebridge listeners.
+        this._transitioning = false;
+
+        this.pane = document.createElement("div");
+        this.pane.classList.add("hidden");
+        this.pane.id = "done";
+        this.pane.innerHTML = `
+            <div class="text-center">
+                <h2>설정이 완료되었습니다.</h2>
+                <p>이제 <span class="brand-name">DL E&C</span> 아파트의 가구를 애플 기기에서 제어할 수 있습니다.</p>
+                <button type="button" id="advanced-button" class="btn btn-secondary" disabled>고급</button>
+                <button type="button" id="reset-button" class="btn btn-primary">재설정</button>
+                <button type="button" id="done-button" class="btn btn-primary">닫기</button>
+            </div>
+        `;
+        this.advancedButton = this.pane.querySelector("#advanced-button");
+        this.resetButton = this.pane.querySelector("#reset-button");
+        this.doneButton = this.pane.querySelector("#done-button");
+    }
+
+    selfPane() {
+        return this.pane;
+    }
+
+    canPassthrough() {
+        // this is the EOP (end-of-pane)
+        return false;
+    }
+
+    nextPane() {
+        return new ResetConfirmablePane(this.element, this.config);
+    }
+
+    _settle(warning) {
+        if(this._settled) {
+            return; // only the first terminal state wins
+        }
+        this._settled = true;
+        this._advancedUnlocked = true;
+        this.advancedButton.removeAttribute("disabled");
+        if(warning) {
+            window.homebridge.toast.warning(warning);
+        }
+    }
+
+    _setActionButtonsDisabled(disabled) {
+        // The advanced button only ever unlocks through `_settle()`.
+        this.advancedButton.disabled = disabled || !this._advancedUnlocked;
+        this.resetButton.disabled = disabled;
+        this.doneButton.disabled = disabled;
+    }
+
+    // Every way off this pane goes through here: one transition at a time, all
+    // action buttons dead while it runs, and both restored if it fails.
+    async _transitionTo(makePane) {
+        if(this._transitioning) {
+            return;
+        }
+        this._transitioning = true;
+        this._setActionButtonsDisabled(true);
+        try {
+            await this.advance({}, makePane());
+        } catch(error) {
+            console.error("Leaving the completion screen failed:", error);
+            this._transitioning = false;
+            this._setActionButtonsDisabled(false);
+        }
+    }
+
+    async _requestRefresh() {
         window.homebridge.showSpinner();
         try {
             await window.homebridge.request(`/${this.config.provider}/fetch-devices`, {
@@ -984,12 +1218,11 @@ class CompletePane extends Pane {
                 // The saved device list rides along as the yardstick the server holds
                 // fetched pages against. Empty on a first-time setup, and ignored by daelim.
                 devices: this.config.devices || [],
-                force: !!force,
             });
         } catch(error) {
             console.error("Refreshing devices failed:", error);
             if(this.config.provider === "smart-elife") {
-                this._handleRefreshFailure();
+                await this._handleRefreshFailure();
             } else {
                 // daelim keeps its original terminal state: the saved list stays editable.
                 this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
@@ -999,21 +1232,17 @@ class CompletePane extends Pane {
         }
     }
 
-    _handleRefreshFailure() {
+    async _handleRefreshFailure() {
         this._refreshed = true;
         if(this._advancedFormOpened) {
             return;
         }
-        if(this._confirmMode === "first" || this._confirmMode === "diff") {
-            // A re-fetch from a confirmation screen came back empty-handed.
-            // The candidate on screen is left exactly as it was.
-            window.homebridge.toast.warning(DEVICE_REFRESH_KEPT_MESSAGE);
-            return;
-        }
         if((this.config.devices || []).length === 0) {
             // First-time setup with nothing fetched - there is nothing to edit yet,
-            // so the only way forward is asking again.
-            this._showConfirm("first-failed");
+            // so the only way forward is asking again, and the confirmation pane
+            // owns the retry.
+            await this._transitionTo(() => new DeviceConfirmPane(this.element, this.config,
+                { mode: "first-failed" }));
             return;
         }
         // A refresh for an existing configuration failed. The advanced editor stays
@@ -1044,14 +1273,23 @@ class CompletePane extends Pane {
     register() {
         this.ensureAttached();
         refreshTrademark(this.config);
-        setTimeout(async () => {
-            await this._requestRefresh(false);
-            if(this.config.provider === "smart-elife" && !this._refreshed) {
-                // The handler awaits the whole sign-in,
-                // so returning without having reported any device means the query gave up quietly.
-                this._handleRefreshFailure();
-            }
-        }, 0);
+        if(this._openAdvancedOnRegister) {
+            // The confirmation pane already fetched, judged and saved the list on the
+            // resident's way to the editor - fetching again here would only replay it.
+            this._settle();
+            setTimeout(async () => {
+                await this._openAdvancedForm();
+            }, 0);
+        } else {
+            setTimeout(async () => {
+                await this._requestRefresh();
+                if(this.config.provider === "smart-elife" && !this._refreshed) {
+                    // The handler awaits the whole sign-in,
+                    // so returning without having reported any device means the query gave up quietly.
+                    await this._handleRefreshFailure();
+                }
+            }, 0);
+        }
 
         this.addHomebridgeListener("authorization-failed", () => {
             this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
@@ -1061,11 +1299,10 @@ class CompletePane extends Pane {
             this._settle(WALLPAD_REAUTHORIZATION_MESSAGE);
         });
         this.addHomebridgeListener("device-refresh-failed", () => {
-            this._handleRefreshFailure();
+            void this._handleRefreshFailure();
         });
         this.addHomebridgeListener("devices-fetched", async (event) => {
             const devices = event["data"].devices;
-            this._pendingAliases = event["data"].aliases || {};
             console.log(`Num of devices: ${devices.length}`);
 
             this._refreshed = true; // mark before yielding, the request may settle next
@@ -1075,18 +1312,15 @@ class CompletePane extends Pane {
                 // Replacing the list now would silently discard those edits.
                 return;
             }
+            if(this._transitioning) {
+                // Already on the way off this pane (재설정, 닫기, or an earlier list);
+                // a late list must not race that transition with another one.
+                return;
+            }
 
             const savedDevices = this.config.devices || [];
-            const availableDevices = [];
-            for(const device of devices) {
-                const equiv = savedDevices
-                    .filter(oldDevice => this.devicesEquals(oldDevice, device));
-                if(!equiv || !equiv.length) {
-                    availableDevices.push(device);
-                } else {
-                    availableDevices.push(equiv[0]);
-                }
-            }
+            const {availableDevices, added, removed} = mergeFetchedDevices(
+                this.config.provider, savedDevices, devices);
 
             if(this.config.provider !== "smart-elife") {
                 // daelim: the per-complex server answers for this household alone,
@@ -1099,55 +1333,59 @@ class CompletePane extends Pane {
             }
 
             // smart-elife: nothing is saved here. The fetched list is a candidate until
-            // the resident presses '확인하고 저장' - that press is the confirmation the
-            // household judgement stands on ever after.
-            this._pendingDevices = availableDevices;
-            this._pendingAdded = devices.filter(device =>
-                !savedDevices.some(oldDevice => this.devicesEquals(oldDevice, device)));
-            this._pendingRemoved = savedDevices.filter(oldDevice =>
-                !availableDevices.some(device => this.devicesEquals(oldDevice, device)));
-
+            // the resident confirms it on DeviceConfirmPane - that press is the
+            // confirmation the household judgement stands on ever after.
+            const aliases = event["data"].aliases || {};
             if(savedDevices.length === 0) {
                 // First-time setup: the list itself is the screen.
-                this._showConfirm("first");
+                await this._transitionTo(() => new DeviceConfirmPane(this.element, this.config,
+                    { mode: "first", devices: availableDevices, added, removed, aliases }));
                 return;
             }
-            if(this._pendingAdded.length === 0 && this._pendingRemoved.length === 0) {
+            if(added.length === 0 && removed.length === 0) {
                 // Nothing changed - saving would be a no-op, so there is nothing to confirm.
-                this._pendingDevices = null;
-                const wasRetryFromDiff = this._confirmMode === "diff";
-                this._showDone();
+                this._pendingFetch = null;
                 this._settle();
-                if(wasRetryFromDiff) {
-                    // The re-fetch converged with the saved list;
-                    // continue to the editor the resident was headed for.
-                    await this._openAdvancedForm();
-                }
-                return;
-            }
-            if(this._confirmMode === "diff") {
-                // A re-fetch changed the picture - redraw it against the saved list.
-                this._showConfirm("diff");
                 return;
             }
             // The confirmation waits until the resident actually goes for the editor.
+            this._pendingFetch = { devices: availableDevices, added, removed, aliases };
             this._settle();
         });
         this.addListener(this.resetButton, "click", async () => {
-            await this.advance({}, this.nextPane());
+            await this._transitionTo(() => this.nextPane());
         });
         this.addListener(this.doneButton, "click", async () => {
-            await this.updatePluginConfig();
-            await this.savePluginConfig();
+            if(this._transitioning) {
+                return;
+            }
+            // 닫기 holds the latch like every other way off this pane: its awaits
+            // leave a window where 재설정 or 고급 would register a pane the close
+            // then pulls down, and a double click would save and close twice.
+            this._transitioning = true;
+            this._setActionButtonsDisabled(true);
+            try {
+                await this.updatePluginConfig();
+                await this.savePluginConfig();
+            } catch(error) {
+                console.error("Saving the configuration failed:", error);
+                window.homebridge.toast.warning(SETTINGS_SAVE_FAILED_MESSAGE);
+                this._transitioning = false;
+                this._setActionButtonsDisabled(false);
+                return;
+            }
             window.homebridge.closeSettings();
         });
 
         this.addListener(this.advancedButton, "click", async () => {
-            if(this.config.provider === "smart-elife" && this._pendingDevices
-                && (this._pendingAdded.length > 0 || this._pendingRemoved.length > 0)) {
+            if(this._transitioning) {
+                return;
+            }
+            if(this.config.provider === "smart-elife" && this._pendingFetch) {
                 // The fetched list differs from the saved one - show what saving would
                 // change before the editor built on that list opens.
-                this._showConfirm("diff");
+                await this._transitionTo(() => new DeviceConfirmPane(this.element, this.config,
+                    { mode: "diff", ...this._pendingFetch }));
                 return;
             }
             await this._openAdvancedForm();

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -745,6 +745,7 @@ const WALLPAD_REAUTHORIZATION_MESSAGE = "월패드 재인증이 필요합니다.
 const DEVICE_REFRESH_KEPT_MESSAGE = "기기 목록을 조회하지 못했습니다. 저장된 설정은 그대로 유지됩니다.";
 const DEVICE_SAVE_FAILED_MESSAGE = "기기 목록을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.";
 const SETTINGS_SAVE_FAILED_MESSAGE = "설정을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.";
+const SETTINGS_RESET_FAILED_MESSAGE = "설정을 초기화하지 못했습니다. 잠시 후 다시 시도해주세요.";
 
 const DEVICE_TYPE_LABELS = {
     "light": "조명",
@@ -1472,6 +1473,11 @@ class ResetConfirmablePane extends Pane {
     constructor(element, config) {
         super(element, config);
 
+        // Reset and cancel both await host/server work before leaving this pane.
+        // A second click in that window would otherwise register another pane (or,
+        // after the first click clears the provider, request /undefined/invalidate).
+        this._transitioning = false;
+
         this.pane = document.createElement("div");
         this.pane.classList.add("hidden");
         this.pane.id = "confirmable";
@@ -1495,33 +1501,87 @@ class ResetConfirmablePane extends Pane {
         return this.pane;
     }
 
+    _setButtonsDisabled(disabled) {
+        this.confirmButton.disabled = disabled;
+        this.cancelButton.disabled = disabled;
+    }
+
+    _recoverTransition(error, message) {
+        console.error("Leaving the reset confirmation screen failed:", error);
+        window.homebridge.toast.warning(message);
+        this._transitioning = false;
+        this._setButtonsDisabled(false);
+    }
+
     register() {
         this.ensureAttached();
         this.addListener(this.confirmButton, "click", async () => {
+            if(this._transitioning) {
+                return;
+            }
+            this._transitioning = true;
+            this._setButtonsDisabled(true);
             window.homebridge.showSpinner();
 
             const provider = this.config.provider;
+            const previousConfig = {...this.config};
 
-            // invalidate all.
-            this.config.provider = undefined;
-            this.config.region = undefined;
-            this.config.complex = undefined;
-            this.config.username = undefined;
-            this.config.password = undefined;
-            this.config.uuid = undefined;
-            this.config.devices = [];
+            try {
+                if(!provider) {
+                    throw new Error("Cannot reset settings without a provider.");
+                }
 
-            await window.homebridge.request(`/${provider}/invalidate`, {});
-            await this.updatePluginConfig();
-            await this.savePluginConfig();
+                // invalidate all.
+                this.config.provider = undefined;
+                this.config.region = undefined;
+                this.config.complex = undefined;
+                this.config.username = undefined;
+                this.config.password = undefined;
+                this.config.uuid = undefined;
+                this.config.devices = [];
+
+                await window.homebridge.request(`/${provider}/invalidate`, {});
+                await this.updatePluginConfig();
+                await this.savePluginConfig();
+            } catch(error) {
+                // Keep a failed reset retryable. The request or save may have failed
+                // after the shared config object was cleared, so put the old values back
+                // before re-enabling either button.
+                for(const key of Object.keys(this.config)) {
+                    delete this.config[key];
+                }
+                Object.assign(this.config, previousConfig);
+                try {
+                    await this.updatePluginConfig();
+                } catch {
+                    // The next successful reset or pane transition rewrites the block.
+                }
+                refreshTrademark(this.config);
+                window.homebridge.hideSpinner();
+                this._recoverTransition(error, SETTINGS_RESET_FAILED_MESSAGE);
+                return;
+            }
 
             refreshTrademark(this.config);
             window.homebridge.hideSpinner();
 
-            await this.advance({}, new ProviderPane(this.element, this.config));
+            try {
+                await this.advance({}, new ProviderPane(this.element, this.config));
+            } catch(error) {
+                this._recoverTransition(error, SETTINGS_RESET_FAILED_MESSAGE);
+            }
         });
         this.addListener(this.cancelButton, "click", async () => {
-            await this.advance({}, new CompletePane(this.element, this.config));
+            if(this._transitioning) {
+                return;
+            }
+            this._transitioning = true;
+            this._setButtonsDisabled(true);
+            try {
+                await this.advance({}, new CompletePane(this.element, this.config));
+            } catch(error) {
+                this._recoverTransition(error, SETTINGS_SAVE_FAILED_MESSAGE);
+            }
         });
     }
 }

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -576,6 +576,9 @@ class AuthorizationPane extends Pane {
                 complex: this.config.complex,
                 username: this.usernameElement.value,
                 password: this.passwordElement.value,
+                // The saved device list rides along as the yardstick the server holds
+                // fetched pages against. Empty on a first-time setup, and ignored by daelim.
+                devices: this.config.devices || [],
             });
         });
         this.addHomebridgeListener("authorization-failed", (event) => {
@@ -685,6 +688,8 @@ class WallpadPasscodePane extends Pane {
                 username: this.config.username,
                 password: this.config.password,
                 passcode: this.passcodeElement.value,
+                // Rides through to the sign-in this passcode completes - see AuthorizationPane.
+                devices: this.config.devices || [],
             });
         });
         this.addHomebridgeListener("invalid-wallpad-passcode", async () => {
@@ -792,6 +797,9 @@ class CompletePane extends Pane {
                     complex: this.config.complex,
                     username: this.config.username,
                     password: this.config.password,
+                    // The saved device list rides along as the yardstick the server holds
+                    // fetched pages against. Empty on a first-time setup, and ignored by daelim.
+                    devices: this.config.devices || [],
                 });
                 if(this.config.provider === "smart-elife" && !this._refreshed) {
                     // The handler awaits the whole sign-in,

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -578,15 +578,18 @@ class AuthorizationPane extends Pane {
                     element.classList.add("hidden");
                 }
             }
-            await window.homebridge.request(`/${this.provider}/sign-in`, {
+            const payload = {
                 region: this.config.region,
                 complex: this.config.complex,
                 username: this.usernameElement.value,
                 password: this.passwordElement.value,
+            };
+            if(this.provider === "smart-elife") {
                 // The saved device list rides along as the yardstick the server holds
-                // fetched pages against. Empty on a first-time setup, and ignored by daelim.
-                devices: this.config.devices || [],
-            });
+                // fetched pages against. Empty on a first-time setup.
+                payload.devices = this.config.devices || [];
+            }
+            await window.homebridge.request(`/${this.provider}/sign-in`, payload);
         });
         this.addHomebridgeListener("authorization-failed", (event) => {
             const reasonId = event["data"].reason;
@@ -696,14 +699,17 @@ class WallpadPasscodePane extends Pane {
             this.verifyButton.disabled = true;
             stopTimer();
             window.homebridge.showSpinner();
-            await window.homebridge.request(`/${this.config.provider}/passcode`, {
+            const payload = {
                 complex: this.config.complex,
                 username: this.config.username,
                 password: this.config.password,
                 passcode: this.passcodeElement.value,
+            };
+            if(this.provider === "smart-elife") {
                 // Rides through to the sign-in this passcode completes - see AuthorizationPane.
-                devices: this.config.devices || [],
-            });
+                payload.devices = this.config.devices || [];
+            }
+            await window.homebridge.request(`/${this.config.provider}/passcode`, payload);
         });
         this.addHomebridgeListener("invalid-wallpad-passcode", async () => {
             window.homebridge.hideSpinner();
@@ -1274,16 +1280,19 @@ class CompletePane extends Pane {
 
     async _requestRefresh() {
         window.homebridge.showSpinner();
+        const payload = {
+            region: this.config.region,
+            complex: this.config.complex,
+            username: this.config.username,
+            password: this.config.password,
+        };
+        if(this.config.provider === "smart-elife") {
+            // The saved device list rides along as the yardstick the server holds
+            // fetched pages against. Empty on a first-time setup.
+            payload.devices = this.config.devices || [];
+        }
         try {
-            await window.homebridge.request(`/${this.config.provider}/fetch-devices`, {
-                region: this.config.region,
-                complex: this.config.complex,
-                username: this.config.username,
-                password: this.config.password,
-                // The saved device list rides along as the yardstick the server holds
-                // fetched pages against. Empty on a first-time setup, and ignored by daelim.
-                devices: this.config.devices || [],
-            });
+            await window.homebridge.request(`/${this.config.provider}/fetch-devices`, payload);
         } catch(error) {
             console.error("Refreshing devices failed:", error);
             if(this.config.provider === "smart-elife") {

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -841,13 +841,16 @@ class CompletePane extends Pane {
         const aside = this._pendingAliases[device.deviceId] || "";
         return `<li class="list-group-item d-flex justify-content-between align-items-center py-1 px-3">
             <span${strike}>${escapeHtml(displayName)}${label}</span>
-            <small class="text-muted">${escapeHtml(aside)}</small>
+            <small style="opacity: .65;">${escapeHtml(aside)}</small>
         </li>`;
     }
 
     _deviceGroupHeader(title) {
-        return `<li class="list-group-item py-1 px-3 bg-light">
-            <small class="font-weight-bold text-muted">${escapeHtml(title)}</small>
+        // Styled with inherited colour and translucency rather than bootstrap's
+        // bg-light/text-muted, which assume a light theme - Config UI X renders
+        // this pane in the resident's theme, dark included.
+        return `<li class="list-group-item py-1 px-3" style="background: rgba(127, 127, 127, .12);">
+            <small class="font-weight-bold" style="opacity: .75;">${escapeHtml(title)}</small>
         </li>`;
     }
 
@@ -875,8 +878,8 @@ class CompletePane extends Pane {
         if(this._confirmMode === "first-failed") {
             return `
                 <div class="text-center">
-                    <h4>기기 목록을 조회하지 못했습니다.</h4>
-                    <p class="small text-muted mb-3">잠시 후 '다시 조회'를 눌러주세요.</p>
+                    <h2>기기 목록을 조회하지 못했습니다.</h2>
+                    <p>잠시 후 '다시 조회'를 눌러주세요.</p>
                     <button type="button" id="refetch-button" class="btn btn-secondary">다시 조회</button>
                 </div>
             `;
@@ -884,8 +887,8 @@ class CompletePane extends Pane {
         if(this._confirmMode === "first") {
             return `
                 <div class="text-center">
-                    <h4>기기 목록을 확인해주세요.</h4>
-                    <p class="small text-muted mb-2">${this._pendingDevices.length}개의 기기가 조회되었습니다. 아래 목록이 맞는지 확인해주세요.</p>
+                    <h2>기기 목록을 확인해주세요.</h2>
+                    <p>${this._pendingDevices.length}개의 기기가 조회되었습니다. 아래 목록이 맞는지 확인해주세요.</p>
                 </div>
                 <ul class="list-group mb-3 text-left" style="max-height: 220px; overflow-y: auto; font-size: 14px;">
                     ${this._deviceListRows(this._pendingDevices)}
@@ -906,12 +909,12 @@ class CompletePane extends Pane {
             rows.push(this._deviceRow(device, "removed"));
         }
         rows.push(`<li class="list-group-item py-1 px-3 text-center">
-            <small class="text-muted">외 ${keptCount}개 유지</small>
+            <small style="opacity: .65;">외 ${keptCount}개 유지</small>
         </li>`);
         return `
             <div class="text-center">
-                <h4>기기 목록에 달라진 내용이 있습니다.</h4>
-                <p class="small text-muted mb-2">달라진 내용이 사실이 아니라면 '다시 조회'를 눌러주세요.<br>
+                <h2>기기 목록에 달라진 내용이 있습니다.</h2>
+                <p>달라진 내용이 사실이 아니라면 '다시 조회'를 눌러주세요.<br>
                 '확인하고 저장'을 누르기 전까지 기존 설정은 그대로 유지됩니다.</p>
             </div>
             <ul class="list-group mb-3 text-left" style="max-height: 200px; overflow-y: auto; font-size: 14px;">

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -723,6 +723,32 @@ class WallpadPasscodePane extends Pane {
 
 const DEVICE_REFRESH_FAILED_MESSAGE = "기기 목록을 갱신하지 못했습니다. 저장된 목록으로 설정을 편집합니다.";
 const WALLPAD_REAUTHORIZATION_MESSAGE = "월패드 재인증이 필요합니다. 기기 목록을 갱신하려면 '재설정'으로 다시 로그인해주세요.";
+const DEVICE_REFRESH_KEPT_MESSAGE = "기기 목록을 조회하지 못했습니다. 저장된 설정은 그대로 유지됩니다.";
+
+const DEVICE_TYPE_LABELS = {
+    "light": "조명",
+    "heat": "난방",
+    "wallsocket": "콘센트",
+    "vent": "환기",
+    "gas": "가스",
+    "aircon": "에어컨",
+    "aircon2": "에어컨",
+    "alloffswitch": "일괄소등",
+    "indoorair": "공기질",
+    "elevator": "엘리베이터",
+    "door": "현관",
+    "smartdoor": "도어락",
+    "vehicle": "주차",
+    "camera": "초인종 카메라",
+};
+
+function escapeHtml(text) {
+    return String(text ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+}
 
 class CompletePane extends Pane {
     constructor(element, config) {
@@ -734,18 +760,30 @@ class CompletePane extends Pane {
         this._refreshed = false;
         this._advancedFormOpened = false;
 
+        // What the last fetch reported, held until the resident explicitly saves it.
+        // The config keeps its saved list all the while - that list is also the yardstick
+        // the server judges fetched pages against, so replacing it must be a decision.
+        this._pendingDevices = null;
+        this._pendingAdded = [];
+        this._pendingRemoved = [];
+        // Which confirmation screen is showing: "first", "first-failed", "diff", or null.
+        this._confirmMode = null;
+
         this.pane = document.createElement("div");
         this.pane.classList.add("hidden");
         this.pane.id = "done";
         this.pane.innerHTML = `
-            <div class="text-center">
+            <div class="text-center" id="done-main">
                 <h2>설정이 완료되었습니다.</h2>
                 <p>이제 <span class="brand-name">DL E&C</span> 아파트의 가구를 애플 기기에서 제어할 수 있습니다.</p>
                 <button type="button" id="advanced-button" class="btn btn-secondary" disabled>고급</button>
                 <button type="button" id="reset-button" class="btn btn-primary">재설정</button>
                 <button type="button" id="done-button" class="btn btn-primary">닫기</button>
             </div>
+            <div class="hidden" id="device-confirm"></div>
         `;
+        this.doneMain = this.pane.querySelector("#done-main");
+        this.confirmContainer = this.pane.querySelector("#device-confirm");
         this.advancedButton = this.pane.querySelector("#advanced-button");
         this.resetButton = this.pane.querySelector("#reset-button");
         this.doneButton = this.pane.querySelector("#done-button");
@@ -787,35 +825,233 @@ class CompletePane extends Pane {
         }
     }
 
+    _deviceRow(device, badge) {
+        const label = badge === "removed"
+            ? `<span class="badge badge-danger ml-2">빠짐</span>`
+            : badge === "added"
+                ? `<span class="badge badge-success ml-2">추가</span>`
+                : "";
+        const strike = badge === "removed" ? ` style="text-decoration: line-through;"` : "";
+        return `<li class="list-group-item d-flex justify-content-between align-items-center py-1 px-3">
+            <span${strike}>${escapeHtml(device.displayName || device.deviceId)}${label}</span>
+            <small class="text-muted">${escapeHtml(device.deviceType)}</small>
+        </li>`;
+    }
+
+    _deviceGroupHeader(title) {
+        return `<li class="list-group-item py-1 px-3 bg-light">
+            <small class="font-weight-bold text-muted">${escapeHtml(title)}</small>
+        </li>`;
+    }
+
+    // The whole fetched list, grouped by device type in order of first appearance.
+    _deviceListRows(devices) {
+        const groups = new Map();
+        for(const device of devices) {
+            const label = DEVICE_TYPE_LABELS[device.deviceType] || device.deviceType;
+            if(!groups.has(label)) {
+                groups.set(label, []);
+            }
+            groups.get(label).push(device);
+        }
+        const rows = [];
+        for(const [label, members] of groups) {
+            rows.push(this._deviceGroupHeader(label));
+            for(const device of members) {
+                rows.push(this._deviceRow(device));
+            }
+        }
+        return rows.join("");
+    }
+
+    _confirmScreenHtml() {
+        if(this._confirmMode === "first-failed") {
+            return `
+                <div class="text-center">
+                    <h4>기기 목록을 조회하지 못했습니다.</h4>
+                    <p class="small text-muted mb-3">잠시 후 '다시 조회'를 눌러주세요.</p>
+                    <button type="button" id="refetch-button" class="btn btn-secondary">다시 조회</button>
+                </div>
+            `;
+        }
+        if(this._confirmMode === "first") {
+            return `
+                <div class="text-center">
+                    <h4>기기 목록을 확인해주세요.</h4>
+                    <p class="small text-muted mb-2">${this._pendingDevices.length}개의 기기가 조회되었습니다. 아래 목록이 맞는지 확인해주세요.</p>
+                </div>
+                <ul class="list-group mb-3 text-left" style="max-height: 220px; overflow-y: auto; font-size: 14px;">
+                    ${this._deviceListRows(this._pendingDevices)}
+                </ul>
+                <div class="text-center">
+                    <button type="button" id="refetch-button" class="btn btn-secondary">다시 조회</button>
+                    <button type="button" id="confirm-save-button" class="btn btn-primary">확인하고 저장</button>
+                </div>
+            `;
+        }
+        // "diff": what an explicit save would add and take away, against the saved list.
+        const keptCount = this._pendingDevices.length - this._pendingAdded.length;
+        const rows = [this._deviceGroupHeader("변경")];
+        for(const device of this._pendingAdded) {
+            rows.push(this._deviceRow(device, "added"));
+        }
+        for(const device of this._pendingRemoved) {
+            rows.push(this._deviceRow(device, "removed"));
+        }
+        rows.push(`<li class="list-group-item py-1 px-3 text-center">
+            <small class="text-muted">외 ${keptCount}개 유지</small>
+        </li>`);
+        return `
+            <div class="text-center">
+                <h4>기기 목록에 달라진 내용이 있습니다.</h4>
+                <p class="small text-muted mb-2">달라진 내용이 사실이 아니라면 '다시 조회'를 눌러주세요.<br>
+                '확인하고 저장'을 누르기 전까지 기존 설정은 그대로 유지됩니다.</p>
+            </div>
+            <ul class="list-group mb-3 text-left" style="max-height: 200px; overflow-y: auto; font-size: 14px;">
+                ${rows.join("")}
+            </ul>
+            <div class="text-center">
+                <button type="button" id="refetch-button" class="btn btn-secondary">다시 조회</button>
+                <button type="button" id="confirm-save-button" class="btn btn-primary">확인하고 저장</button>
+            </div>
+        `;
+    }
+
+    _showConfirm(mode) {
+        this._confirmMode = mode;
+        this.confirmContainer.innerHTML = this._confirmScreenHtml();
+        this.doneMain.classList.add("hidden");
+        this.confirmContainer.classList.remove("hidden");
+
+        const refetchButton = this.confirmContainer.querySelector("#refetch-button");
+        if(refetchButton) {
+            this.addListener(refetchButton, "click", async () => {
+                refetchButton.disabled = true;
+                await this._requestRefresh(true);
+                refetchButton.disabled = false;
+            });
+        }
+        const confirmButton = this.confirmContainer.querySelector("#confirm-save-button");
+        if(confirmButton) {
+            this.addListener(confirmButton, "click", async () => {
+                confirmButton.disabled = true;
+                await this._confirmSave();
+            });
+        }
+    }
+
+    _showDone() {
+        this._confirmMode = null;
+        this.confirmContainer.classList.add("hidden");
+        this.confirmContainer.innerHTML = "";
+        this.doneMain.classList.remove("hidden");
+    }
+
+    async _confirmSave() {
+        const mode = this._confirmMode;
+        this.config.devices = this._pendingDevices;
+        await this.updatePluginConfig();
+        await this.savePluginConfig();
+        this._pendingDevices = null;
+        this._pendingAdded = [];
+        this._pendingRemoved = [];
+        this._showDone();
+        this._settle();
+        if(mode === "diff") {
+            // The resident was on their way to the editor - continue there.
+            await this._openAdvancedForm();
+        }
+    }
+
+    async _requestRefresh(force) {
+        window.homebridge.showSpinner();
+        try {
+            await window.homebridge.request(`/${this.config.provider}/fetch-devices`, {
+                region: this.config.region,
+                complex: this.config.complex,
+                username: this.config.username,
+                password: this.config.password,
+                // The saved device list rides along as the yardstick the server holds
+                // fetched pages against. Empty on a first-time setup, and ignored by daelim.
+                devices: this.config.devices || [],
+                force: !!force,
+            });
+        } catch(error) {
+            console.error("Refreshing devices failed:", error);
+            if(this.config.provider === "smart-elife") {
+                this._handleRefreshFailure();
+            } else {
+                // daelim keeps its original terminal state: the saved list stays editable.
+                this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
+            }
+        } finally {
+            window.homebridge.hideSpinner();
+        }
+    }
+
+    _handleRefreshFailure() {
+        this._refreshed = true;
+        if(this._advancedFormOpened) {
+            return;
+        }
+        if(this._confirmMode === "first" || this._confirmMode === "diff") {
+            // A re-fetch from a confirmation screen came back empty-handed.
+            // The candidate on screen is left exactly as it was.
+            window.homebridge.toast.warning(DEVICE_REFRESH_KEPT_MESSAGE);
+            return;
+        }
+        if((this.config.devices || []).length === 0) {
+            // First-time setup with nothing fetched - there is nothing to edit yet,
+            // so the only way forward is asking again.
+            this._showConfirm("first-failed");
+            return;
+        }
+        // A refresh for an existing configuration failed. The advanced editor stays
+        // locked - the fetched list it would edit does not exist - and nothing is saved.
+        // Closing and reopening the settings retries, because a failure never
+        // replaces the server's device cache.
+        window.homebridge.toast.warning(DEVICE_REFRESH_KEPT_MESSAGE);
+        this._settled = true;
+    }
+
+    async _openAdvancedForm() {
+        this._advancedFormOpened = true;
+
+        document.getElementById("setupForm").classList.add("hidden");
+        document.getElementById("footer").classList.add("hidden");
+        document.getElementById("advancedForm").classList.remove("hidden");
+
+        await this.updatePluginConfig();
+
+        const configSchema = await window.homebridge.getPluginConfigSchema();
+        const configForm = window.homebridge.createForm(configSchema, this.config);
+        configForm.onChange((change) => {
+            Object.assign(this.config, change);
+            this.updatePluginConfig();
+        });
+    }
+
     register() {
         this.ensureAttached();
         refreshTrademark(this.config);
         setTimeout(async () => {
-            try {
-                await window.homebridge.request(`/${this.config.provider}/fetch-devices`, {
-                    region: this.config.region,
-                    complex: this.config.complex,
-                    username: this.config.username,
-                    password: this.config.password,
-                    // The saved device list rides along as the yardstick the server holds
-                    // fetched pages against. Empty on a first-time setup, and ignored by daelim.
-                    devices: this.config.devices || [],
-                });
-                if(this.config.provider === "smart-elife" && !this._refreshed) {
-                    // The handler awaits the whole sign-in,
-                    // so returning without having reported any device means the query gave up quietly.
-                    this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
-                }
-            } catch(error) {
-                console.error("Could not refresh the device list:", error);
-                this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
+            await this._requestRefresh(false);
+            if(this.config.provider === "smart-elife" && !this._refreshed) {
+                // The handler awaits the whole sign-in,
+                // so returning without having reported any device means the query gave up quietly.
+                this._handleRefreshFailure();
             }
         }, 0);
+
         this.addHomebridgeListener("authorization-failed", () => {
             this._settle(DEVICE_REFRESH_FAILED_MESSAGE);
         });
+        // Wallpad certification expired; the resident has to sign in again to refresh.
         this.addHomebridgeListener("require-wallpad-passcode", () => {
             this._settle(WALLPAD_REAUTHORIZATION_MESSAGE);
+        });
+        this.addHomebridgeListener("device-refresh-failed", () => {
+            this._handleRefreshFailure();
         });
         this.addHomebridgeListener("devices-fetched", async (event) => {
             const devices = event["data"].devices;
@@ -841,28 +1077,49 @@ class CompletePane extends Pane {
                 }
             }
 
-            // Say what this refresh takes away, before it is saved.
-            // A saved entry the new list still names survives, and one it does not is dropped
-            // without a word - while `/main/home.do` intermittently answers with another
-            // household's page. So a refresh can quietly remove devices the resident still has,
-            // and the runtime then judges every later page against what is left.
-            // Naming the losses is what makes saving the list a decision rather than an assumption.
-            const removed = savedDevices.filter(oldDevice =>
-                !availableDevices.some(device => this.devicesEquals(oldDevice, device)));
-            if(savedDevices.length && removed.length) {
-                const shown = removed.slice(0, 5)
-                    .map(device => device.displayName || device.deviceId).join(", ");
-                const rest = removed.length > shown.split(", ").length ? ` 외 ${removed.length - 5}개` : "";
-                window.homebridge.toast.warning(
-                    `${shown}${rest}. 이 세대의 기기가 맞다면 '재설정'으로 다시 조회해주세요.`,
-                    `기기 ${removed.length}개가 목록에서 빠졌습니다`);
+            if(this.config.provider !== "smart-elife") {
+                // daelim: the per-complex server answers for this household alone,
+                // so the fetched list needs no confirmation.
+                this.config.devices = availableDevices;
+                await this.updatePluginConfig();
+                await this.savePluginConfig();
+                this._settle();
+                return;
             }
-            console.log(`Devices: ${savedDevices.length} saved, ${availableDevices.length} after refresh, ${removed.length} dropped`);
 
-            this.config.devices = availableDevices;
-            await this.updatePluginConfig();
-            await this.savePluginConfig();
+            // smart-elife: nothing is saved here. The fetched list is a candidate until
+            // the resident presses '확인하고 저장' - that press is the confirmation the
+            // household judgement stands on ever after.
+            this._pendingDevices = availableDevices;
+            this._pendingAdded = devices.filter(device =>
+                !savedDevices.some(oldDevice => this.devicesEquals(oldDevice, device)));
+            this._pendingRemoved = savedDevices.filter(oldDevice =>
+                !availableDevices.some(device => this.devicesEquals(oldDevice, device)));
 
+            if(savedDevices.length === 0) {
+                // First-time setup: the list itself is the screen.
+                this._showConfirm("first");
+                return;
+            }
+            if(this._pendingAdded.length === 0 && this._pendingRemoved.length === 0) {
+                // Nothing changed - saving would be a no-op, so there is nothing to confirm.
+                this._pendingDevices = null;
+                const wasRetryFromDiff = this._confirmMode === "diff";
+                this._showDone();
+                this._settle();
+                if(wasRetryFromDiff) {
+                    // The re-fetch converged with the saved list;
+                    // continue to the editor the resident was headed for.
+                    await this._openAdvancedForm();
+                }
+                return;
+            }
+            if(this._confirmMode === "diff") {
+                // A re-fetch changed the picture - redraw it against the saved list.
+                this._showConfirm("diff");
+                return;
+            }
+            // The confirmation waits until the resident actually goes for the editor.
             this._settle();
         });
         this.addListener(this.resetButton, "click", async () => {
@@ -875,20 +1132,14 @@ class CompletePane extends Pane {
         });
 
         this.addListener(this.advancedButton, "click", async () => {
-            this._advancedFormOpened = true;
-
-            document.getElementById("setupForm").classList.add("hidden");
-            document.getElementById("footer").classList.add("hidden");
-            document.getElementById("advancedForm").classList.remove("hidden");
-
-            await this.updatePluginConfig();
-
-            const configSchema = await window.homebridge.getPluginConfigSchema();
-            const configForm = window.homebridge.createForm(configSchema, this.config);
-            configForm.onChange((change) => {
-                Object.assign(this.config, change);
-                this.updatePluginConfig();
-            });
+            if(this.config.provider === "smart-elife" && this._pendingDevices
+                && (this._pendingAdded.length > 0 || this._pendingRemoved.length > 0)) {
+                // The fetched list differs from the saved one - show what saving would
+                // change before the editor built on that list opens.
+                this._showConfirm("diff");
+                return;
+            }
+            await this._openAdvancedForm();
         });
     }
 

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -545,9 +545,14 @@ class AuthorizationPane extends Pane {
 
     nextPane() {
         if(this.isCompleted) {
-            // The confirmation pane sits before the completion screen and decides
-            // for itself whether there is anything to confirm - see canPassthrough.
-            return new DeviceConfirmPane(this.element, this.config);
+            if(this.provider === "smart-elife") {
+                // The confirmation pane sits before the completion screen and decides
+                // for itself whether there is anything to confirm - see canPassthrough.
+                return new DeviceConfirmPane(this.element, this.config);
+            }
+            // daelim: the per-complex server answers for this household alone,
+            // so the fetched list needs no confirmation.
+            return new CompletePane(this.element, this.config);
         } else {
             return new WallpadPasscodePane(this.element, this.config, this.provider);
         }
@@ -666,9 +671,13 @@ class WallpadPasscodePane extends Pane {
     }
 
     nextPane() {
-        // Same station as AuthorizationPane's: the confirmation pane decides
-        // for itself whether there is anything to confirm.
-        return new DeviceConfirmPane(this.element, this.config);
+        if(this.provider === "smart-elife") {
+            // Same station as AuthorizationPane's: the confirmation pane decides
+            // for itself whether there is anything to confirm.
+            return new DeviceConfirmPane(this.element, this.config);
+        }
+        // daelim: no confirmation - see AuthorizationPane.
+        return new CompletePane(this.element, this.config);
     }
 
     register() {
@@ -797,13 +806,18 @@ function mergeFetchedDevices(provider, savedDevices, fetchedDevices) {
  * judgement stands on ever after - and '다시 조회' asks the server again, which signs
  * in anew and reads the page right after, the most reliable moment there is (#198).
  *
+ * Exclusive to the Smart eLife provider, whose device list cannot be trusted as
+ * fetched: the sign-in panes route only smart-elife here, and canPassthrough keeps
+ * a provider check as a second line of defence. daelim's per-complex server answers
+ * for one household alone, so its wizard skips this procedure entirely.
+ *
  * A member of the wizard chain, between the sign-in panes and CompletePane. Finished
- * settings pass straight through - daelim needs no confirmation, and a saved list is
- * a confirmed one - while a first-time setup stops here, asks the server, and shows
- * what it got: "loading" becomes "first" (the whole fetched list), or "first-failed"
- * (retry as the only way forward). CompletePane also enters it explicitly with a
- * payload, which never passes through: "diff" shows what a re-fetch would add and
- * take away, on the way into the advanced editor.
+ * settings pass straight through - a saved list is a confirmed one - while a
+ * first-time setup stops here, asks the server, and shows what it got: "loading"
+ * becomes "first" (the whole fetched list), or "first-failed" (retry as the only way
+ * forward). CompletePane also enters it explicitly with a payload, which never
+ * passes through: "diff" shows what a re-fetch would add and take away, on the way
+ * into the advanced editor.
  */
 class DeviceConfirmPane extends Pane {
     constructor(element, config, payload) {
@@ -843,7 +857,9 @@ class DeviceConfirmPane extends Pane {
             return false;
         }
         // As a chain member it only stops the wizard where nothing is confirmed yet:
-        // daelim needs no confirmation, and a saved list means a confirmed one.
+        // a saved list means a confirmed one. The provider clause is defence in
+        // depth - the sign-in panes only route smart-elife here - so a misrouted
+        // daelim chain would still pass through untouched.
         return this.config.provider !== "smart-elife"
             || (this.config.devices || []).length > 0;
     }

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -821,9 +821,10 @@ class CompletePane extends Pane {
                 return;
             }
 
+            const savedDevices = this.config.devices || [];
             const availableDevices = [];
             for(const device of devices) {
-                const equiv = (this.config.devices || [])
+                const equiv = savedDevices
                     .filter(oldDevice => this.devicesEquals(oldDevice, device));
                 if(!equiv || !equiv.length) {
                     availableDevices.push(device);
@@ -831,6 +832,25 @@ class CompletePane extends Pane {
                     availableDevices.push(equiv[0]);
                 }
             }
+
+            // Say what this refresh takes away, before it is saved.
+            // A saved entry the new list still names survives, and one it does not is dropped
+            // without a word - while `/main/home.do` intermittently answers with another
+            // household's page. So a refresh can quietly remove devices the resident still has,
+            // and the runtime then judges every later page against what is left.
+            // Naming the losses is what makes saving the list a decision rather than an assumption.
+            const removed = savedDevices.filter(oldDevice =>
+                !availableDevices.some(device => this.devicesEquals(oldDevice, device)));
+            if(savedDevices.length && removed.length) {
+                const shown = removed.slice(0, 5)
+                    .map(device => device.displayName || device.deviceId).join(", ");
+                const rest = removed.length > shown.split(", ").length ? ` 외 ${removed.length - 5}개` : "";
+                window.homebridge.toast.warning(
+                    `${shown}${rest}. 이 세대의 기기가 맞다면 '재설정'으로 다시 조회해주세요.`,
+                    `기기 ${removed.length}개가 목록에서 빠졌습니다`);
+            }
+            console.log(`Devices: ${savedDevices.length} saved, ${availableDevices.length} after refresh, ${removed.length} dropped`);
+
             this.config.devices = availableDevices;
             await this.updatePluginConfig();
             await this.savePluginConfig();

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -545,7 +545,9 @@ class AuthorizationPane extends Pane {
 
     nextPane() {
         if(this.isCompleted) {
-            return new CompletePane(this.element, this.config);
+            // The confirmation pane sits before the completion screen and decides
+            // for itself whether there is anything to confirm - see canPassthrough.
+            return new DeviceConfirmPane(this.element, this.config);
         } else {
             return new WallpadPasscodePane(this.element, this.config, this.provider);
         }
@@ -664,7 +666,9 @@ class WallpadPasscodePane extends Pane {
     }
 
     nextPane() {
-        return new CompletePane(this.element, this.config);
+        // Same station as AuthorizationPane's: the confirmation pane decides
+        // for itself whether there is anything to confirm.
+        return new DeviceConfirmPane(this.element, this.config);
     }
 
     register() {
@@ -793,16 +797,23 @@ function mergeFetchedDevices(provider, savedDevices, fetchedDevices) {
  * judgement stands on ever after - and '다시 조회' asks the server again, which signs
  * in anew and reads the page right after, the most reliable moment there is (#198).
  *
- * Shown by CompletePane in one of three modes: "first" (a first-time setup showing
- * the whole fetched list), "first-failed" (a first-time setup whose fetch failed,
- * with retry as the only way forward), and "diff" (an existing configuration whose
- * re-fetch differs from the saved list, on the way into the advanced editor).
+ * A member of the wizard chain, between the sign-in panes and CompletePane. Finished
+ * settings pass straight through - daelim needs no confirmation, and a saved list is
+ * a confirmed one - while a first-time setup stops here, asks the server, and shows
+ * what it got: "loading" becomes "first" (the whole fetched list), or "first-failed"
+ * (retry as the only way forward). CompletePane also enters it explicitly with a
+ * payload, which never passes through: "diff" shows what a re-fetch would add and
+ * take away, on the way into the advanced editor.
  */
 class DeviceConfirmPane extends Pane {
     constructor(element, config, payload) {
         super(element, config);
 
-        this._mode = payload.mode;
+        // With a payload this pane was entered deliberately, carrying a judged list;
+        // without one it is a chain member that has to ask the server itself.
+        this._explicit = !!payload;
+        payload = payload || {};
+        this._mode = payload.mode || "loading";
         this._devices = payload.devices || [];
         this._added = payload.added || [];
         this._removed = payload.removed || [];
@@ -827,7 +838,18 @@ class DeviceConfirmPane extends Pane {
     }
 
     canPassthrough() {
-        return false;
+        if(this._explicit) {
+            // Entered deliberately, with a list to confirm - always shown.
+            return false;
+        }
+        // As a chain member it only stops the wizard where nothing is confirmed yet:
+        // daelim needs no confirmation, and a saved list means a confirmed one.
+        return this.config.provider !== "smart-elife"
+            || (this.config.devices || []).length > 0;
+    }
+
+    nextPane() {
+        return new CompletePane(this.element, this.config);
     }
 
     selfPane() {
@@ -838,7 +860,7 @@ class DeviceConfirmPane extends Pane {
         const label = badge === "removed"
             ? `<span class="badge badge-danger ml-2">빠짐</span>`
             : badge === "added"
-                ? `<span class="badge badge-success ml-2">추가</span>`
+                ? `<span class="badge badge-success ml-2">추가됨</span>`
                 : "";
         const strike = badge === "removed" ? ` style="text-decoration: line-through;"` : "";
         const displayName = device.displayName || device.deviceId;
@@ -882,6 +904,14 @@ class DeviceConfirmPane extends Pane {
     }
 
     _screenHtml() {
+        if(this._mode === "loading") {
+            return `
+                <div class="text-center">
+                    <h2>기기 목록을 조회하고 있습니다.</h2>
+                    <p>잠시만 기다려주세요.</p>
+                </div>
+            `;
+        }
         if(this._mode === "first-failed") {
             return `
                 <div class="text-center">
@@ -944,7 +974,7 @@ class DeviceConfirmPane extends Pane {
         }
     }
 
-    async _refetch() {
+    async _refetch(force = true) {
         window.homebridge.showSpinner();
         this._answered = false;
         try {
@@ -956,7 +986,7 @@ class DeviceConfirmPane extends Pane {
                 // The saved device list rides along as the yardstick the server holds
                 // fetched pages against. Empty on a first-time setup.
                 devices: this.config.devices || [],
-                force: true,
+                force: !!force,
             });
         } catch(error) {
             console.error("Refreshing devices failed:", error);
@@ -970,8 +1000,9 @@ class DeviceConfirmPane extends Pane {
 
     _onRefetchFailed() {
         this._answered = true;
-        if(this._mode === "first-failed") {
-            // Still nothing to show; the screen already says so.
+        if(this._mode === "loading" || this._mode === "first-failed") {
+            // Still nothing to show; retry is the only way forward.
+            this._mode = "first-failed";
             this._render();
             return;
         }
@@ -1025,6 +1056,15 @@ class DeviceConfirmPane extends Pane {
         this.ensureAttached();
         refreshTrademark(this.config);
         this._render();
+
+        if(!this._explicit) {
+            // A chain member arrives with nothing and asks the server itself.
+            // The sign-in that brought the wizard this far left its list in the
+            // wizard server's cache, so this resolves without another login.
+            setTimeout(async () => {
+                await this._refetch(false);
+            }, 0);
+        }
 
         // One delegated listener survives every re-render;
         // wiring the buttons anew per render would pile up dead handler bookkeeping.
@@ -1104,10 +1144,19 @@ class DeviceConfirmPane extends Pane {
         this.addHomebridgeListener("authorization-failed", () => {
             this._answered = true;
             window.homebridge.toast.warning(DEVICE_REFRESH_FAILED_MESSAGE);
+            if(this._mode === "loading") {
+                // The loading screen has no buttons to fall back on.
+                this._mode = "first-failed";
+                this._render();
+            }
         });
         this.addHomebridgeListener("require-wallpad-passcode", () => {
             this._answered = true;
             window.homebridge.toast.warning(WALLPAD_REAUTHORIZATION_MESSAGE);
+            if(this._mode === "loading") {
+                this._mode = "first-failed";
+                this._render();
+            }
         });
     }
 }

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -858,7 +858,7 @@ class DeviceConfirmPane extends Pane {
 
     _deviceRow(device, badge) {
         const label = badge === "removed"
-            ? `<span class="badge badge-danger ml-2">빠짐</span>`
+            ? `<span class="badge badge-danger ml-2">제외됨</span>`
             : badge === "added"
                 ? `<span class="badge badge-success ml-2">추가됨</span>`
                 : "";

--- a/homebridge-ui/public/scripts/pane.js
+++ b/homebridge-ui/public/scripts/pane.js
@@ -766,6 +766,8 @@ class CompletePane extends Pane {
         this._pendingDevices = null;
         this._pendingAdded = [];
         this._pendingRemoved = [];
+        // Display-only: the resident's own room names, keyed by device id.
+        this._pendingAliases = {};
         // Which confirmation screen is showing: "first", "first-failed", "diff", or null.
         this._confirmMode = null;
 
@@ -832,9 +834,14 @@ class CompletePane extends Pane {
                 ? `<span class="badge badge-success ml-2">추가</span>`
                 : "";
         const strike = badge === "removed" ? ` style="text-decoration: line-through;"` : "";
+        const displayName = device.displayName || device.deviceId;
+        // The side slot names the room the device is in - the name the resident
+        // gave it where there is one, the canonical name otherwise, and nothing
+        // where the page carried neither.
+        const aside = this._pendingAliases[device.deviceId] || "";
         return `<li class="list-group-item d-flex justify-content-between align-items-center py-1 px-3">
-            <span${strike}>${escapeHtml(device.displayName || device.deviceId)}${label}</span>
-            <small class="text-muted">${escapeHtml(device.deviceType)}</small>
+            <span${strike}>${escapeHtml(displayName)}${label}</span>
+            <small class="text-muted">${escapeHtml(aside)}</small>
         </li>`;
     }
 
@@ -1055,6 +1062,7 @@ class CompletePane extends Pane {
         });
         this.addHomebridgeListener("devices-fetched", async (event) => {
             const devices = event["data"].devices;
+            this._pendingAliases = event["data"].aliases || {};
             console.log(`Num of devices: ${devices.length}`);
 
             this._refreshed = true; // mark before yielding, the request may settle next

--- a/homebridge/accessories/smart-elife/accessories.ts
+++ b/homebridge/accessories/smart-elife/accessories.ts
@@ -1,4 +1,4 @@
-import SmartELifeClient, {Listener, PushListener} from "../../../core/smart-elife/smart-elife-client";
+import SmartELifeClient, {Listener, ListenerMetadata, PushListener} from "../../../core/smart-elife/smart-elife-client";
 import {API, Logging, PlatformAccessory, Service, type WithUUID} from "homebridge";
 import {Device, DeviceType, PushType, SmartELifeConfig} from "../../../core/interfaces/smart-elife-config";
 import {Utils} from "../../../core/utils";
@@ -16,7 +16,7 @@ export interface DeviceWithOp extends Device {
 }
 
 export type NonEmptyDeviceList = [DeviceWithOp, ...DeviceWithOp[]];
-export type DeviceListener = (devices: NonEmptyDeviceList) => void;
+export type DeviceListener = (devices: NonEmptyDeviceList, metadata: ListenerMetadata) => void;
 export type ServiceType = WithUUID<typeof Service>;
 
 const DEFERRED_TASKS_MILLISECONDS = 500;
@@ -206,7 +206,7 @@ export default class Accessories<T extends AccessoryInterface> {
     }
 
     protected addDeviceListener(deviceListener: DeviceListener, deviceType: DeviceType = this.deviceType) {
-        this.addListener((data, error) => {
+        this.addListener((data, error, metadata) => {
             let devices: DeviceWithOp[];
             if(!data || !data["devices"]) {
                 this.log.warn(`Devices (${deviceType.toString()}) not found: (${error.code}) ${error.message ?? "unknown reason"}`);
@@ -225,7 +225,7 @@ export default class Accessories<T extends AccessoryInterface> {
                 return;
             }
 
-            deviceListener(devices as NonEmptyDeviceList);
+            deviceListener(devices as NonEmptyDeviceList, metadata);
         }, deviceType);
     }
 


### PR DESCRIPTION
## Summary

`GET /main/home.do` intermittently answers with a different resident's rendered page. It does so with a plain 200 and nothing that reads as an error, and a day of polling on one household saw between 18 and 42 per cent of pages arrive that way. WallPad `uid`s are only unique inside one household, so such a page does not merely miss ours — it collides with a few of them, and those collisions reached the accessories as their own state.

This holds a report against the configuration before anything acts on it, on both the HTTP and the WebSocket path — and the configuration it holds them against is now something the resident explicitly confirmed, rather than whatever the first fetch happened to return. Closes #198.

**#196 AND #200 DEPEND ON THIS.**

## Root cause

`refreshDeviceStatus()` parsed the rendered page and handed every device group straight to the listeners, and `parseDevices()` matches on `uid` and device type alone. A page belonging to somebody else therefore contributed state for whichever of its `uid`s coincided with ours — measured over two days on one household, 95 wallsocket frames and 11 aircon frames did exactly that.

The same misattribution reaches the socket independently of the page, so guarding one does not guard the other. One room reported `(off, on)` 435 times in that window: a shape its own hardware cannot produce, since switching any flag off collapses the whole room.

## Changes

**Refuse a rendered page that is not this household's.** The judgement moves to the single fetch every consumer reads — the device list, the room names, the WebSocket credentials all come from it — and a page that is not ours reaches neither the accessories nor the socket we would otherwise echo it back to. Asking the server about a stranger's devices is how their answers came back as ours.

Whose household a list is now has four answers rather than two. `HouseholdAttribution` names them: `OWN` and `FOREIGN` where the saved configuration decides by majority, `UNKNOWN` where there is nothing to hold the list against, and `INVALID` where the markup gave the parser nothing. The last two used to be silent passes; naming them is what lets the wizard treat "could not judge" differently from "judged ours", and only an `OWN` page teaches the client which device types to ask the WallPad about. The credentials parser still reads the page whichever household its devices belonged to: every page measured carried this session's own room and user keys, including those whose device list was somebody else's — the server misresolves the household for the list, not for the session.

Where a page is refused, the WallPad is asked instead, so that declining costs freshness rather than sight.

**Refuse a socket frame that is not this household's.** Its two shapes admit different evidence. A query answers with every device of its type and can be held against the configuration exactly as a page is; 91 of those listed another household. A push carries one device, where a majority means nothing, but it does carry the room key the elevator frames already rely on. A frame naming neither is let through — an `elevator_call_request` carries no room key, and the indoor air list answers with a bare header.

A single type has no cushion a whole page has: where the configuration holds none of that type, every answer about it names nobody we know. The all-off switch is exactly that, since `fetchDevices()` never writes it down, so judging only what there is something to judge against leaves it alone.

**Say when a report was observed and whether it is whole.** Reports carried no account of their own age, and the poll is where that costs something: a fetch already in the air when a command is sent returns a page that predates it. Each report is now stamped with a number drawn when the observation was *requested*, from a counter commands draw from too, so "this report predates my command" becomes a comparison rather than an interval to wait out. A counter rather than a clock, because a Raspberry Pi has no RTC and steps its clock once the network comes up.

Reports also say whether they are the whole of their device type — measured, 6496 query answers each carrying all six of this household's lights against 542 pushes each carrying one. Nothing reads either field yet; both are needed by work in flight, and the contract belongs beside the client that stamps it.

The stamp now holds on every path. A polled page draws its number before the HTTP request leaves; the answer to a socket query wears the number drawn when that query was sent, kept in a per-type FIFO and dropped on reconnect; an `event_*` push is never requested, so its number is drawn at receipt. Query answers previously drew at receipt, which let a report predating a command outrank it.

The FIFO holds under failure, too. A query's entry is reserved at the moment the frame is handed to the socket, so a send that never happens reserves nothing, an answer cannot arrive before its entry exists, and a send that rode through a reconnect is not stranded by the clear. A type whose queries stop being answered goes quiet instead of stacking entries nothing will consume, and concurrent calls cannot pass that cap together. The socket itself now bounds a frame at 1 MiB and discards what it cannot parse instead of throwing out of the message handler.

**Ask the resident before saving the fetched device list.** The wizard used to save whatever a fetch returned without showing it, which made the empty-configuration pass above a hole rather than a handoff: the first sign-in judged nothing, and nobody read the list it saved. The frontend now sends the saved list along with every request, so the server judges pages by the resident's own yardstick instead of an empty cache, and nothing is saved without an explicit press. A first-time setup shows the fetched list and saves it only on confirmation; a refresh keeps the finished screen and shows what saving would add and take away only when the resident heads for the advanced editor; and a fetch that fails — a foreign page, or one the parser could not read — reports `device-refresh-failed`, keeps the editor locked, and leaves the saved configuration and the server's cache exactly as they were. Failure is no longer disguised as an empty household either: `fetchDevices()` returns the attribution beside the devices. The re-fetch button bypasses the wizard's process-lifetime device cache (`force`), which until now could only be emptied by a full reset.

The confirmation procedure lives on a pane of its own rather than inside the completion screen, which goes back to its original job. Every way off either pane is single-flight — a double press cannot register the same screen twice or close the window over one it just opened — and a refused save puts the saved list back and hands the screen back instead of leaving it locked until the settings reopen. The editor's lock after a refused refresh is its own state, so an unrelated failure recovery cannot undo it.

## Migration

The Smart eLife wizard no longer saves a fetched device list by itself. A first-time setup shows the list and saves it only on the resident's confirmation; editing an existing configuration keeps the saved list until the changes are confirmed on the way into the advanced editor; a failed refresh changes nothing at all. daelim is untouched — its per-complex server answers for one household only, so its wizard keeps the existing behaviour.

## Testing

- `npm run build` type check on each of the eleven commits.
- The judgement driven with the `uid` sets actually observed in the logs, including every foreign light set and the all-off switch that exposed the missing rule (17 cases).
- The attribution, cache policy, structured fetch result, and observation ordering driven with the network stubbed (26 cases). The ordering case fails when run against the first four commits, reproducing the receive-time stamp it replaces.
- The wizard's server driven with a stubbed client (11 cases): the saved list reaching the judgement, the failure event, the cache surviving a failed refresh, and `force` bypassing it.
- The wizard's frontend driven in a real browser with the host API stubbed: the first-time list screen saving only on confirmation, the refresh diff appearing behind the advanced button and re-fetching with `force`, and a failure locking the editor with nothing saved.
- The FIFO's failure modes driven with a stubbed WebSocket (12 interleavings, 30 checks): silent drops, sends straddling a reconnect, answers outrunning their own send callback, late frames from a replaced socket, and concurrent calls against the cap. Each check reproduced its defect on the pre-fix build first.
- The wizard's exclusivity and recovery driven in the same stubbed browser: double presses on every way off both screens, a refused save reverting the device list and reviving the buttons, and the editor's lock surviving an unrelated failure recovery.
- The first four commits ran on a Raspberry Pi against a live household. The wizard rework has not run against the live server yet; it was verified with the stubs above.
