### PR TITLE
Reflect wallpad state with updateCharacteristic rather than setCharacteristic

### DIFF
--- a/homebridge/accessories/daelim/door.ts
+++ b/homebridge/accessories/daelim/door.ts
@@ -78,7 +78,7 @@ export class DoorAccessories extends Accessories<DoorAccessoryInterface> {
 
     refreshSensors(accessory: PlatformAccessory) {
         this.findService(accessory, this.api.hap.Service.MotionSensor, (service) => {
-            service.setCharacteristic(this.api.hap.Characteristic.MotionDetected, accessory.context.changesDetected);
+            service.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, accessory.context.changesDetected);
         });
     }
 

--- a/homebridge/accessories/daelim/elevator.ts
+++ b/homebridge/accessories/daelim/elevator.ts
@@ -51,7 +51,7 @@ export class ElevatorAccessories extends Accessories<ElevatorAccessoryInterface>
                         // If the elevator have called, but attempt to set not-called state
                         const nextState = accessory.context.called;
                         setTimeout(() => {
-                            service.setCharacteristic(this.api.hap.Characteristic.On, nextState);
+                            service.updateCharacteristic(this.api.hap.Characteristic.On, nextState);
                         }, 0);
                     }
                     callback(undefined);
@@ -102,7 +102,7 @@ export class ElevatorAccessories extends Accessories<ElevatorAccessoryInterface>
             accessory.context.timeoutId = -1;
             accessory.context.called = false;
             this.findService(accessory, this.api.hap.Service.Switch, (service) => {
-                service.setCharacteristic(this.api.hap.Characteristic.On, accessory.context.called);
+                service.updateCharacteristic(this.api.hap.Characteristic.On, accessory.context.called);
             });
         }
     }

--- a/homebridge/accessories/daelim/fan.ts
+++ b/homebridge/accessories/daelim/fan.ts
@@ -171,9 +171,9 @@ export class FanAccessories extends Accessories<FanAccessoryInterface> {
                 ctx.init = true;
                 if(force) {
                     this.findService(accessory, this.api.hap.Service.Fan, (service) => {
-                        service.setCharacteristic(this.api.hap.Characteristic.On, ctx.active ? 1 : 0);
+                        service.updateCharacteristic(this.api.hap.Characteristic.On, ctx.active ? 1 : 0);
                         if(this.client?.doesComplexMatch(FAN_SPEED_SUPPORTED_COMPLEXES)) {
-                            service.setCharacteristic(this.api.hap.Characteristic.RotationSpeed, this.getRotationSpeedPercentage(ctx));
+                            service.updateCharacteristic(this.api.hap.Characteristic.RotationSpeed, this.getRotationSpeedPercentage(ctx));
                         }
                     });
                 }

--- a/homebridge/accessories/daelim/gas.ts
+++ b/homebridge/accessories/daelim/gas.ts
@@ -129,8 +129,8 @@ export class GasAccessories extends Accessories<GasAccessoryInterface> {
                 accessory.context.init = true;
                 if(force) {
                     this.findService(accessory, this.api.hap.Service.LockMechanism, (service) => {
-                        service.setCharacteristic(this.api.hap.Characteristic.LockCurrentState, accessory.context.on ? this.api.hap.Characteristic.LockCurrentState.UNSECURED : this.api.hap.Characteristic.LockCurrentState.SECURED);
-                        service.setCharacteristic(this.api.hap.Characteristic.LockTargetState, accessory.context.on ? this.api.hap.Characteristic.LockCurrentState.UNSECURED : this.api.hap.Characteristic.LockCurrentState.SECURED);
+                        service.updateCharacteristic(this.api.hap.Characteristic.LockCurrentState, accessory.context.on ? this.api.hap.Characteristic.LockCurrentState.UNSECURED : this.api.hap.Characteristic.LockCurrentState.SECURED);
+                        service.updateCharacteristic(this.api.hap.Characteristic.LockTargetState, accessory.context.on ? this.api.hap.Characteristic.LockCurrentState.UNSECURED : this.api.hap.Characteristic.LockCurrentState.SECURED);
                     })
                 }
             }

--- a/homebridge/accessories/daelim/heater-cooler.ts
+++ b/homebridge/accessories/daelim/heater-cooler.ts
@@ -81,11 +81,14 @@ export abstract class HeaterCoolerAccessories extends Accessories<HeaterCoolerAc
                 callback(undefined, this.getCurrentHeaterCoolerState(accessory));
             });
 
+        // Props before the value throughout: a value written first is clamped to the
+        // range HAP gives the characteristic by default, which is narrower than the
+        // one being installed right after it.
         service.getCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState)
-            .setValue(this.getTargetHeaterCoolerState())
             .setProps({
                 validValues: this.getAvailableTargetHeaterCoolerStates(),
             })
+            .updateValue(this.getTargetHeaterCoolerState())
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
                 // NOTE: No need to update heater state
                 callback(undefined);
@@ -98,12 +101,12 @@ export abstract class HeaterCoolerAccessories extends Accessories<HeaterCoolerAc
             });
 
         service.getCharacteristic(this.getThresholdTemperatureCharacteristic())
-            .setValue(this.getThresholdTemperature(accessory))
             .setProps({
                 minValue: this.minimumTemperature,
                 maxValue: this.maximumTemperature,
                 minStep: 1
             })
+            .updateValue(this.getThresholdTemperature(accessory))
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
                 if(accessory.context.desiredTemperature === value || !accessory.context.active) {
                     // Temperature slider is disabled when the accessory is not active
@@ -138,7 +141,7 @@ export abstract class HeaterCoolerAccessories extends Accessories<HeaterCoolerAc
             });
 
         service.getCharacteristic(this.api.hap.Characteristic.CurrentTemperature)
-            .setValue(this.getCurrentTemperature(accessory))
+            .updateValue(this.getCurrentTemperature(accessory))
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 if(!this.checkAccessoryAvailability(accessory, callback)) {
                     return;
@@ -166,11 +169,11 @@ export abstract class HeaterCoolerAccessories extends Accessories<HeaterCoolerAc
                 accessory.context.init = true;
                 if(force) {
                     this.findService(accessory, this.api.hap.Service.HeaterCooler, (service) => {
-                        service.setCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.getCurrentTemperature(accessory));
-                        service.setCharacteristic(this.api.hap.Characteristic.Active, accessory.context.active ? this.api.hap.Characteristic.Active.ACTIVE : this.api.hap.Characteristic.Active.INACTIVE);
-                        service.setCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState, this.getCurrentHeaterCoolerState(accessory));
-                        service.setCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState, this.getTargetHeaterCoolerState());
-                        service.setCharacteristic(this.getThresholdTemperatureCharacteristic(), this.getThresholdTemperature(accessory));
+                        service.updateCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.getCurrentTemperature(accessory));
+                        service.updateCharacteristic(this.api.hap.Characteristic.Active, accessory.context.active ? this.api.hap.Characteristic.Active.ACTIVE : this.api.hap.Characteristic.Active.INACTIVE);
+                        service.updateCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState, this.getCurrentHeaterCoolerState(accessory));
+                        service.updateCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState, this.getTargetHeaterCoolerState());
+                        service.updateCharacteristic(this.getThresholdTemperatureCharacteristic(), this.getThresholdTemperature(accessory));
                     });
                 }
             }

--- a/homebridge/accessories/daelim/lightbulb.ts
+++ b/homebridge/accessories/daelim/lightbulb.ts
@@ -238,7 +238,7 @@ export class LightbulbAccessories extends Accessories<LightbulbAccessoryInterfac
                 ctx.init = true;
                 if(force) {
                     this.findService(accessory, this.api.hap.Service.Lightbulb, (service) => {
-                        service.setCharacteristic(this.api.hap.Characteristic.On, ctx.on);
+                        service.updateCharacteristic(this.api.hap.Characteristic.On, ctx.on);
                     });
                 }
 
@@ -273,7 +273,7 @@ export class LightbulbAccessories extends Accessories<LightbulbAccessoryInterfac
                         if(force) {
                             this.findService(accessory, this.api.hap.Service.Lightbulb, (service) => {
                                 const brightness = settings.getBrightness(Math.min(ctx.maxBrightness, ctx.brightness), settings)
-                                service.setCharacteristic(this.api.hap.Characteristic.Brightness, brightness);
+                                service.updateCharacteristic(this.api.hap.Characteristic.Brightness, brightness);
                             });
                         }
                     }

--- a/homebridge/accessories/daelim/outlet.ts
+++ b/homebridge/accessories/daelim/outlet.ts
@@ -102,7 +102,7 @@ export class OutletAccessories extends Accessories<OutletAccessoryInterface> {
                 accessory.context.init = true;
                 if(force) {
                     this.findService(accessory, this.api.hap.Service.Outlet, (service) => {
-                        service.setCharacteristic(this.api.hap.Characteristic.On, accessory.context.on);
+                        service.updateCharacteristic(this.api.hap.Characteristic.On, accessory.context.on);
                     });
                 }
             }

--- a/homebridge/accessories/daelim/vehicle.ts
+++ b/homebridge/accessories/daelim/vehicle.ts
@@ -56,7 +56,7 @@ export class VehicleAccessories extends Accessories<VehicleAccessoryInterface> {
 
     refreshSensors(accessory: PlatformAccessory) {
         this.findService(accessory, this.api.hap.Service.MotionSensor, (service) => {
-            service.setCharacteristic(this.api.hap.Characteristic.MotionDetected, accessory.context.vehicleGettingIn);
+            service.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, accessory.context.vehicleGettingIn);
         });
     }
 

--- a/homebridge/accessories/smart-elife/door.ts
+++ b/homebridge/accessories/smart-elife/door.ts
@@ -234,11 +234,11 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                 context.motionDetected = false;
 
                 accessory.getService(this.api.hap.Service.MotionSensor)
-                    ?.setCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
+                    ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
             }, (device.duration?.door || DOOR_TIMEOUT_DURATION_SECONDS) * 1000);
 
             accessory.getService(this.api.hap.Service.MotionSensor)
-                ?.setCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
+                ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
         });
     }
 

--- a/homebridge/accessories/smart-elife/heater.ts
+++ b/homebridge/accessories/smart-elife/heater.ts
@@ -48,10 +48,13 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
         // TargetHeaterCoolerState
         this.getService(accessory, this.api.hap.Service.HeaterCooler)
             .getCharacteristic(this.api.hap.Characteristic.TargetHeaterCoolerState)
-            .setValue(this.api.hap.Characteristic.TargetHeaterCoolerState.HEAT)
+            // Props before the value throughout: a value written first is clamped to the
+            // range HAP gives the characteristic by default, which is narrower than the
+            // one being installed right after it.
             .setProps({
                 validValues: [this.api.hap.Characteristic.TargetHeaterCoolerState.HEAT],
             })
+            .updateValue(this.api.hap.Characteristic.TargetHeaterCoolerState.HEAT)
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 callback(undefined, this.api.hap.Characteristic.TargetHeaterCoolerState.HEAT);
             });
@@ -59,12 +62,12 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
         // HeatingThresholdTemperature
         this.getService(accessory, this.api.hap.Service.HeaterCooler)
             .getCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature)
-            .setValue(this.getThresholdTemperature(accessory))
             .setProps({
                 minValue: MIN_TEMPERATURE,
                 maxValue: MAX_TEMPERATURE,
                 minStep: 1,
             })
+            .updateValue(this.getThresholdTemperature(accessory))
             .on(CharacteristicEventTypes.SET, async (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
                 const context = this.getAccessoryInterface(accessory);
                 if(context.desiredTemperature === value || !context.active) {
@@ -98,7 +101,7 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
         // CurrentTemperature
         this.getService(accessory, this.api.hap.Service.HeaterCooler)
             .getCharacteristic(this.api.hap.Characteristic.CurrentTemperature)
-            .setValue(this.getCurrentTemperature(accessory))
+            .updateValue(this.getCurrentTemperature(accessory))
             .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
                 callback(undefined, this.getCurrentTemperature(accessory));
             });
@@ -151,12 +154,12 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
 
                 const context = this.getAccessoryInterface(accessory);
                 accessory.getService(this.api.hap.Service.HeaterCooler)
-                    ?.setCharacteristic(this.api.hap.Characteristic.Active, context.active
+                    ?.updateCharacteristic(this.api.hap.Characteristic.Active, context.active
                         ? this.api.hap.Characteristic.Active.ACTIVE
                         : this.api.hap.Characteristic.Active.INACTIVE)
-                    .setCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState, this.getCurrentState(accessory))
-                    .setCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature, this.getThresholdTemperature(accessory))
-                    .setCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.getCurrentTemperature(accessory));
+                    .updateCharacteristic(this.api.hap.Characteristic.CurrentHeaterCoolerState, this.getCurrentState(accessory))
+                    .updateCharacteristic(this.api.hap.Characteristic.HeatingThresholdTemperature, this.getThresholdTemperature(accessory))
+                    .updateCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.getCurrentTemperature(accessory));
             }
         });
     }

--- a/homebridge/accessories/smart-elife/outlet.ts
+++ b/homebridge/accessories/smart-elife/outlet.ts
@@ -27,7 +27,7 @@ export default class OutletAccessories extends OnOffAccessories<OutletAccessoryI
 
                 const context = this.getAccessoryInterface(accessory);
                 const service = accessory.getService(this.api.hap.Service.Outlet);
-                service?.setCharacteristic(this.api.hap.Characteristic.On, context.on);
+                service?.updateCharacteristic(this.api.hap.Characteristic.On, context.on);
             }
         });
     }

--- a/homebridge/accessories/smart-elife/vehicle.ts
+++ b/homebridge/accessories/smart-elife/vehicle.ts
@@ -66,11 +66,11 @@ export default class VehicleAccessories extends Accessories<VehicleAccessoryInte
                 context.motionDetected = false;
 
                 accessory.getService(this.api.hap.Service.MotionSensor)
-                    ?.setCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
+                    ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
             }, (device.duration?.vehicle || VEHICLE_TIMEOUT_DURATION_SECONDS) * 1000);
 
             accessory.getService(this.api.hap.Service.MotionSensor)
-                ?.setCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
+                ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
         });
     }
 


### PR DESCRIPTION
## Summary

Reflecting wallpad state onto HomeKit went through `setCharacteristic`, which runs the SET handler — the path reserved for a user asking for something. This converts every such reflection to `updateCharacteristic`/`updateValue` across both providers, and fixes the two spots where the mismatch produced real commands. Closes #204.

## Root cause

Every SET handler opens with an early-return guard comparing the incoming value against the context. The guard holds only while the two are the same number, and HAP passes the value through the characteristic's props (range clamp, `minStep` rounding) on the way in while the context never goes near them. The heater's target temperature is where that comes apart: a wallpad report of 45 is clamped to the declared 5–40 and 22.5 is rounded by `minStep: 1`, so the handler is handed a number the context does not hold, reads it as a request, and pushes `set_temp` back at the wallpad.

## Changes

- State reflection now uses `updateCharacteristic`/`updateValue` across 12 files in both providers — refresh paths, register listeners, motion sensors, and the current-value characteristics that have no SET handler at all. `AccessoryInformation` keeps `setCharacteristic`: a static plugin-supplied value with no handler to run is the standard idiom.
- `configureAccessory` chains install `.setProps()` before the initial value. Written the other way around, the value was clamped to HAP's default range before the very next line widened it — the heater's 40 °C target was pinned to the default ceiling of 25.
- Recent reworks (#195, #196, #200, #203) already use the correct pattern, so their files carry no changes here.

## Testing

- `npm run build` passes.
- A smoke harness drives the built heater class with a stubbed client, run against the previous code first and then this branch. Before: a `desired_temp` report of 45 came back as `set_temp: 40`, 22.5 came back rounded, and the initial 40 was pinned to 25. After: no command leaves the accessory, the characteristic still reflects the clamped value (proving the reflection path ran), and 40 lands as 40. 6/6 checks in both phases.
- Verified against a live wallpad with this branch deployed: startup is clean, dragging the heater target through 36 -> 16 -> 19 °C was accepted and echoed back within a few seconds each, and none of the reflected reports produced an outgoing command. The out-of-range triggers themselves cannot be produced on demand from a real wallpad, which is what the harness above covers.