### PR TITLE
Record the Smart eLife accessory reports that succeed, not only the ones that fail

### DIFF
--- a/homebridge/accessories/smart-elife/air-conditioner.ts
+++ b/homebridge/accessories/smart-elife/air-conditioner.ts
@@ -770,6 +770,46 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
      * written with `updateCharacteristic`, which does not run the SET handlers, so
      * reflecting a state can never bounce a command back at the wallpad.
      */
+    /**
+     * Whether anything `applyAccessoryState()` is about to write would land as a change.
+     *
+     * All three services are asked, because a mode change can move one while leaving
+     * the others where they were:
+     * off to dehumidifying leaves the climate side inactive and the fan stopped
+     * and shows up only on the dehumidifier,
+     * and a wind change between high and auto keeps the same displayed speed
+     * while flipping the fan's target state.
+     */
+    private publishDiffers(accessory: PlatformAccessory,
+                           context: AirConditionerInterface,
+                           climate: boolean, blowing: boolean, dehumidifying: boolean): boolean {
+        const hap = this.api.hap;
+        const activeValue = (on: boolean) => on
+            ? hap.Characteristic.Active.ACTIVE
+            : hap.Characteristic.Active.INACTIVE;
+
+        const climateService = this.getService(accessory, hap.Service.HeaterCooler);
+        const fan = this.getService(accessory, hap.Service.Fanv2);
+        const dehumidifier = this.getService(accessory, hap.Service.HumidifierDehumidifier);
+
+        return climateService.getCharacteristic(hap.Characteristic.Active).value !== activeValue(climate)
+            || climateService.getCharacteristic(hap.Characteristic.CurrentHeaterCoolerState).value !== this.getCurrentState(context)
+            || climateService.getCharacteristic(hap.Characteristic.TargetHeaterCoolerState).value !== this.getHeaterCoolerTargetState(context)
+            // Rounded the way HAP stores it: `minStep` is one degree, so a wallpad report
+            // of 22.5 is held as 23, and comparing the raw number would differ every poll.
+            || climateService.getCharacteristic(hap.Characteristic.CoolingThresholdTemperature).value !== Math.round(this.getDisplayCoolingThreshold(context))
+            || climateService.getCharacteristic(hap.Characteristic.RotationSpeed).value !== this.getDisplayRotationSpeed(context)
+            || fan.getCharacteristic(hap.Characteristic.Active).value !== activeValue(blowing)
+            || fan.getCharacteristic(hap.Characteristic.TargetFanState).value !== (this.isWindAuto(context)
+                ? hap.Characteristic.TargetFanState.AUTO
+                : hap.Characteristic.TargetFanState.MANUAL)
+            // The fan's own speed as well: HomeKit can write one service's slider ahead of
+            // the other, and the write that later realigns the fan is a change on its own.
+            || fan.getCharacteristic(hap.Characteristic.RotationSpeed).value !== this.getDisplayRotationSpeed(context)
+            || dehumidifier.getCharacteristic(hap.Characteristic.Active).value !== activeValue(dehumidifying)
+            || dehumidifier.getCharacteristic(hap.Characteristic.CurrentHumidifierDehumidifierState).value !== this.getCurrentDehumidifierState(context);
+    }
+
     private applyAccessoryState(accessory: PlatformAccessory) {
         const context = this.getAccessoryInterface(accessory);
         // While a gesture is being gathered or carried out, the context still follows
@@ -782,6 +822,18 @@ export default class AirConditionerAccessories extends Accessories<AirConditione
         const climate = this.isClimateActive(context);
         const blowing = this.isBlowing(context);
         const dehumidifying = context.active && context.mode === Mode.DEHUMIDIFYING;
+
+        // Say so only where something will actually go out.
+        // The WallPad is polled every thirty seconds,
+        // so a unit nobody has touched would be announced on every poll.
+        // A gesture of ours logs its own commands,
+        // which leaves a line here without one as the wallpad
+        // or the official app having moved it.
+        if(this.publishDiffers(accessory, context, climate, blowing, dehumidifying)) {
+            this.log.debug("AirConditioner :: %s :: publishing active=%s mode=%s temp=%s wind=%s",
+                context.displayName, context.active ? "on" : "off", String(context.mode),
+                String(context.desiredTemperature), String(context.rotationSpeed));
+        }
 
         this.getService(accessory, this.api.hap.Service.HeaterCooler)
             .updateCharacteristic(this.api.hap.Characteristic.Active, climate

--- a/homebridge/accessories/smart-elife/camera.ts
+++ b/homebridge/accessories/smart-elife/camera.ts
@@ -271,6 +271,7 @@ export default class CameraAccessories extends Accessories<CameraAccessoryInterf
                 clearTimeout(context.motionTimer);
             cameraInfo.snapshot = await reformatSnapshot(this.processorPath, this.log, context.displayName, buffer);
 
+            const holdSeconds = device.duration?.camera || CAMERA_TIMEOUT_DURATION;
             context.cameraInfo = cameraInfo;
             context.motionTimer = setTimeout(() => {
                 const context = this.getAccessoryInterface(accessory);
@@ -280,11 +281,14 @@ export default class CameraAccessories extends Accessories<CameraAccessoryInterf
                 context.motionTimer = undefined;
                 context.motionDetected = false;
 
+                this.log.debug("Camera :: %s :: reporting the motion as over", context.displayName);
                 accessory.getService(this.api.hap.Service.MotionSensor)
                     ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
-            }, (device.duration?.camera || CAMERA_TIMEOUT_DURATION) * 1000);
+            }, holdSeconds * 1000);
             context.motionDetected = true;
 
+            this.log.debug("Camera :: %s :: reporting the motion as detected, holding it for %d seconds",
+                context.displayName, holdSeconds);
             accessory.getService(this.api.hap.Service.MotionSensor)
                 ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
         });

--- a/homebridge/accessories/smart-elife/camera.ts
+++ b/homebridge/accessories/smart-elife/camera.ts
@@ -271,6 +271,12 @@ export default class CameraAccessories extends Accessories<CameraAccessoryInterf
                 clearTimeout(context.motionTimer);
             cameraInfo.snapshot = await reformatSnapshot(this.processorPath, this.log, context.displayName, buffer);
 
+            // A visitor push is a one-shot event,
+            // so the swap is unconditional - there is no poll to repeat it.
+            // Only the failures to get here were on the record before.
+            this.log.debug("Camera :: %s :: replacing the snapshot with a %d byte still",
+                context.displayName, cameraInfo.snapshot?.length || 0);
+
             const holdSeconds = device.duration?.camera || CAMERA_TIMEOUT_DURATION;
             context.cameraInfo = cameraInfo;
             context.motionTimer = setTimeout(() => {

--- a/homebridge/accessories/smart-elife/door.ts
+++ b/homebridge/accessories/smart-elife/door.ts
@@ -224,6 +224,7 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                 clearTimeout(context.motionTimer);
             }
 
+            const holdSeconds = device.duration?.door || DOOR_TIMEOUT_DURATION_SECONDS;
             context.motionDetected = true;
             context.motionTimer = setTimeout(() => {
                 const context = this.getAccessoryInterface(accessory);
@@ -233,10 +234,13 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
                 context.motionTimer = undefined;
                 context.motionDetected = false;
 
+                this.log.debug("Door :: %s :: reporting the motion as over", context.displayName);
                 accessory.getService(this.api.hap.Service.MotionSensor)
                     ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
-            }, (device.duration?.door || DOOR_TIMEOUT_DURATION_SECONDS) * 1000);
+            }, holdSeconds * 1000);
 
+            this.log.debug("Door :: %s :: reporting the motion as detected, holding it for %d seconds",
+                context.displayName, holdSeconds);
             accessory.getService(this.api.hap.Service.MotionSensor)
                 ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
         });

--- a/homebridge/accessories/smart-elife/door.ts
+++ b/homebridge/accessories/smart-elife/door.ts
@@ -190,14 +190,26 @@ export default class DoorAccessories extends Accessories<DoorAccessoryInterface>
             this.log.debug("Ignoring unknown smartdoor status: %s", String(status));
         }
         if(context.closed !== undefined) {
-            accessory.getService(this.api.hap.Service.ContactSensor)
-                ?.getCharacteristic(this.api.hap.Characteristic.ContactSensorState)
-                .updateValue(this.contactSensorState(context.closed));
+            const contact = accessory.getService(this.api.hap.Service.ContactSensor)
+                ?.getCharacteristic(this.api.hap.Characteristic.ContactSensorState);
+
+            // Say so only where something will actually go out.
+            // The lock is polled every thirty seconds,
+            // and a door nobody has opened is republished on every poll.
+            if(contact && contact.value !== this.contactSensorState(context.closed)) {
+                this.log.debug("SmartDoor :: %s :: reporting the door as %s",
+                    context.displayName, context.closed ? "closed" : "open");
+            }
+            contact?.updateValue(this.contactSensorState(context.closed));
         }
 
         const parsedBatteryLevel = this.parseBatteryLevel(op?.["battery"]);
         if(parsedBatteryLevel === undefined) return;
 
+        if(context.batteryLevel !== parsedBatteryLevel) {
+            this.log.debug("SmartDoor :: %s :: reporting the battery level as %d",
+                context.displayName, parsedBatteryLevel);
+        }
         context.batteryLevel = parsedBatteryLevel;
         const battery = accessory.getService(this.api.hap.Service.Battery);
         battery?.getCharacteristic(this.api.hap.Characteristic.BatteryLevel)

--- a/homebridge/accessories/smart-elife/elevator.ts
+++ b/homebridge/accessories/smart-elife/elevator.ts
@@ -89,6 +89,8 @@ export default class ElevatorAccessories extends Accessories<ElevatorAccessoryIn
         if(context.motionTimer) clearTimeout(context.motionTimer);
 
         context.motionDetected = true;
+        this.log.debug("Elevator :: %s :: reporting the arrival motion as detected, holding it for %d seconds",
+            context.displayName, ELEVATOR_MOTION_DURATION_TIMEOUT_SECONDS);
         this.getService(accessory, this.api.hap.Service.MotionSensor)
             .getCharacteristic(this.api.hap.Characteristic.MotionDetected)
             .updateValue(true);
@@ -100,6 +102,7 @@ export default class ElevatorAccessories extends Accessories<ElevatorAccessoryIn
 
             current.motionTimer = undefined;
             current.motionDetected = false;
+            this.log.debug("Elevator :: %s :: reporting the arrival motion as over", current.displayName);
             this.getService(accessory, this.api.hap.Service.MotionSensor)
                 .getCharacteristic(this.api.hap.Characteristic.MotionDetected)
                 .updateValue(false);

--- a/homebridge/accessories/smart-elife/gas.ts
+++ b/homebridge/accessories/smart-elife/gas.ts
@@ -91,6 +91,14 @@ export default class GasAccessories extends Accessories<GasAccessoryInterface> {
     private updateLockState(accessory: PlatformAccessory) {
         const context = this.getAccessoryInterface(accessory);
         const lock = this.getService(accessory, this.api.hap.Service.LockMechanism);
+
+        // Say so only where something will actually go out.
+        // The device list is polled every thirty seconds,
+        // and a valve nobody has touched is republished on every poll.
+        if(lock.getCharacteristic(this.api.hap.Characteristic.LockCurrentState).value !== this.lockCurrentState(context)) {
+            this.log.debug("Gas :: %s :: reporting the valve as %s",
+                context.displayName, context.secured ? "closed" : "open");
+        }
         lock.getCharacteristic(this.api.hap.Characteristic.LockCurrentState)
             .updateValue(this.lockCurrentState(context));
         lock.getCharacteristic(this.api.hap.Characteristic.LockTargetState)

--- a/homebridge/accessories/smart-elife/heater.ts
+++ b/homebridge/accessories/smart-elife/heater.ts
@@ -6,7 +6,8 @@ import {
     CharacteristicGetCallback, CharacteristicSetCallback,
     CharacteristicValue,
     Logging,
-    PlatformAccessory
+    PlatformAccessory,
+    Service
 } from "homebridge";
 
 interface HeaterAccessoryInterface extends ActiveAccessoryInterface {
@@ -130,6 +131,37 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
         return this.api.hap.Characteristic.CurrentHeaterCoolerState.IDLE;
     }
 
+    // Whether what the listener publishes would land as a change worth a line.
+    // The characteristic itself is the reference rather than the context,
+    // because the context is overwritten by `addOrGetAccessory()` before the report is published.
+    //
+    // The room's own temperature is deliberately not part of this.
+    // It is a live sensor reading that drifts by a degree between polls
+    // with nobody touching anything - one line per poll, measured on a real WallPad -
+    // so including it would keep the line coming every thirty seconds
+    // and bury the log this exists to serve.
+    // It is still printed on the line, where it gives context to the change that did happen.
+    private reportDiffers(service: Service, accessory: PlatformAccessory, context: HeaterAccessoryInterface): boolean {
+        const hap = this.api.hap;
+        const active = context.active ? hap.Characteristic.Active.ACTIVE : hap.Characteristic.Active.INACTIVE;
+        return service.getCharacteristic(hap.Characteristic.Active).value !== active
+            || service.getCharacteristic(hap.Characteristic.CurrentHeaterCoolerState).value !== this.getCurrentState(accessory)
+            || service.getCharacteristic(hap.Characteristic.HeatingThresholdTemperature).value !== this.storedThreshold(accessory);
+    }
+
+    /**
+     * The target temperature as the characteristic will hold it.
+     *
+     * HAP rounds what it is given to `minStep`, which is one degree here,
+     * so a wallpad report of 22.5 is stored as 23.
+     * Comparing the raw number against the stored one would differ on every poll,
+     * and the wallpad does send halves.
+     */
+    private storedThreshold(accessory: PlatformAccessory): number {
+        // Equivalent to HAP's own rounding while `minValue` and `minStep` are whole numbers.
+        return Math.round(this.getThresholdTemperature(accessory) as number);
+    }
+
     register() {
         super.register();
 
@@ -153,6 +185,16 @@ export default class HeaterAccessories extends ActiveAccessories<HeaterAccessory
                 if(!accessory) continue;
 
                 const context = this.getAccessoryInterface(accessory);
+                const service = accessory.getService(this.api.hap.Service.HeaterCooler);
+
+                // Say so only where something will actually go out.
+                // The device list is polled every thirty seconds,
+                // and a room nobody has touched is republished on every poll.
+                if(service && this.reportDiffers(service, accessory, context)) {
+                    this.log.debug("Heater :: %s :: reporting active=%s target=%s current=%s",
+                        context.displayName, context.active ? "on" : "off",
+                        String(this.getThresholdTemperature(accessory)), String(this.getCurrentTemperature(accessory)));
+                }
                 accessory.getService(this.api.hap.Service.HeaterCooler)
                     ?.updateCharacteristic(this.api.hap.Characteristic.Active, context.active
                         ? this.api.hap.Characteristic.Active.ACTIVE

--- a/homebridge/accessories/smart-elife/indoor-air-quality.ts
+++ b/homebridge/accessories/smart-elife/indoor-air-quality.ts
@@ -100,6 +100,27 @@ export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQu
         return Math.max(...values) as CharacteristicValue;
     }
 
+    private readingDiffers(context: IndoorAirQualityAccessoryInterface,
+                           reading: Pick<IndoorAirQualityAccessoryInterface,
+                               "pm10" | "pm2_5" | "co2" | "vocs" | "temperature" | "humidity">): boolean {
+        // `Object.is` rather than `!==` throughout: a missing or non-numeric field parses to
+        // NaN, and NaN differs from itself,
+        // so the same broken response would otherwise read as a fresh reading every minute.
+        const moved = (before: unknown, after: unknown) => !Object.is(before, after);
+        // The grade decides what the AirQuality characteristic shows,
+        // and it arrives from the server on its own rather than being derived here,
+        // so a grade that moves without its density is still a change worth the line.
+        const pollutantMoved = (before: DensityWithQuality | undefined, after: DensityWithQuality) =>
+            moved(before?.density, after.density) || moved(before?.quality, after.quality);
+
+        return pollutantMoved(context.pm10, reading.pm10)
+            || pollutantMoved(context.pm2_5, reading.pm2_5)
+            || pollutantMoved(context.co2, reading.co2)
+            || pollutantMoved(context.vocs, reading.vocs)
+            || moved(context.temperature, reading.temperature)
+            || moved(context.humidity, reading.humidity);
+    }
+
     async fetchAirQuality() {
         if(this.skippedFirstPollingMessage) {
             this.log.info(`Polling device state :: ${this.deviceType.toString()} (${this.accessories.length} accessories)`);
@@ -133,18 +154,48 @@ export default class IndoorAirQualityAccessories extends Accessories<IndoorAirQu
                     humidityCount += 1;
                 }
 
-                this.addOrGetAccessory({
-                    deviceId: device.deviceId,
-                    deviceType: device.deviceType,
-                    displayName: device.displayName,
-                    init: true,
+                const reading = {
                     pm10: { density: Number(info["pm10"]["value"]), quality: AirQuality.parse(info["pm10"]["css"]) },
                     pm2_5: { density: Number(info["pm25"]["value"]), quality: AirQuality.parse(info["pm25"]["css"]) },
                     co2: { density: Number(info["co2"]["value"]), quality: AirQuality.parse(info["co2"]["css"]) },
                     vocs: { density: Number(info["vocs"]["value"]), quality: AirQuality.parse(info["vocs"]["css"]) },
                     temperature: Number(info["temp"]),
                     humidity,
+                };
+
+                const cached = this.findAccessory(device.deviceId);
+                const previous = cached ? { ...this.getAccessoryInterface(cached) } : undefined;
+
+                const accessory = this.addOrGetAccessory({
+                    deviceId: device.deviceId,
+                    deviceType: device.deviceType,
+                    displayName: device.displayName,
+                    init: true,
+                    ...reading,
                 });
+
+                // Say so only when the reading moved, and only once it has somewhere to land.
+                // `findDevice()` hands back devices disabled in the config as well, and those
+                // never become an accessory,
+                // so speaking before this point would claim a reflection that did not happen -
+                // every minute, since no accessory ever turns up to compare against.
+                //
+                // This sensor never publishes - the characteristics are read out of the
+                // context on GET -
+                // so this line is the only record that a cycle landed on the accessory.
+                if(!accessory) continue;
+                if(!previous || this.readingDiffers(previous, reading)) {
+                    // Each pollutant carries its grade alongside the density. The grade is
+                    // what the AirQuality characteristic shows and it arrives from the
+                    // server on its own,
+                    // so without it a grade-only move would print a line identical to the
+                    // previous one.
+                    const pollutant = (value: DensityWithQuality) => `${value.density}/${value.quality}`;
+                    this.log.debug("IndoorAirQuality :: %s :: reading pm10=%s pm2.5=%s co2=%s vocs=%s temp=%s humidity=%s",
+                        device.displayName, pollutant(reading.pm10), pollutant(reading.pm2_5),
+                        pollutant(reading.co2), pollutant(reading.vocs),
+                        String(reading.temperature), String(reading.humidity));
+                }
             } catch(e: any) {
                 this.log.warn("Could not parse air-quality reading for %s: %s", device.displayName, e?.message || e);
             }

--- a/homebridge/accessories/smart-elife/outlet.ts
+++ b/homebridge/accessories/smart-elife/outlet.ts
@@ -27,6 +27,14 @@ export default class OutletAccessories extends OnOffAccessories<OutletAccessoryI
 
                 const context = this.getAccessoryInterface(accessory);
                 const service = accessory.getService(this.api.hap.Service.Outlet);
+
+                // Say so only where something will actually go out.
+                // The device list is polled every thirty seconds,
+                // and an outlet nobody has touched is republished on every poll.
+                if(service && service.getCharacteristic(this.api.hap.Characteristic.On).value !== context.on) {
+                    this.log.debug("Outlet :: %s :: reporting the outlet as %s",
+                        context.displayName, context.on ? "on" : "off");
+                }
                 service?.updateCharacteristic(this.api.hap.Characteristic.On, context.on);
             }
         });

--- a/homebridge/accessories/smart-elife/vehicle.ts
+++ b/homebridge/accessories/smart-elife/vehicle.ts
@@ -56,6 +56,7 @@ export default class VehicleAccessories extends Accessories<VehicleAccessoryInte
                 clearTimeout(context.motionTimer);
             }
 
+            const holdSeconds = device.duration?.vehicle || VEHICLE_TIMEOUT_DURATION_SECONDS;
             context.motionDetected = true;
             context.motionTimer = setTimeout(() => {
                 const context = this.getAccessoryInterface(accessory);
@@ -65,10 +66,13 @@ export default class VehicleAccessories extends Accessories<VehicleAccessoryInte
                 context.motionTimer = undefined;
                 context.motionDetected = false;
 
+                this.log.debug("Vehicle :: %s :: reporting the motion as over", context.displayName);
                 accessory.getService(this.api.hap.Service.MotionSensor)
                     ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
-            }, (device.duration?.vehicle || VEHICLE_TIMEOUT_DURATION_SECONDS) * 1000);
+            }, holdSeconds * 1000);
 
+            this.log.debug("Vehicle :: %s :: reporting the motion as detected, holding it for %d seconds",
+                context.displayName, holdSeconds);
             accessory.getService(this.api.hap.Service.MotionSensor)
                 ?.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, context.motionDetected);
         });

--- a/homebridge/accessories/smart-elife/vent.ts
+++ b/homebridge/accessories/smart-elife/vent.ts
@@ -679,6 +679,33 @@ export default class VentAccessories extends ActiveAccessories<VentAccessoryInte
             return;
         }
         const service = this.getService(accessory, this.api.hap.Service.AirPurifier);
+
+        // Say so only where something will actually go out.
+        // The device reports about every second while it runs,
+        // so a vent nobody has touched would be announced every time.
+        // A gesture of ours logs its own commands,
+        // which leaves what lands here without one as the wallpad
+        // or the official app having moved it.
+        const active = context.active
+            ? this.api.hap.Characteristic.Active.ACTIVE
+            : this.api.hap.Characteristic.Active.INACTIVE;
+        const target = this.isHomeKitAutomaticMode(context.mode)
+            ? this.api.hap.Characteristic.TargetAirPurifierState.AUTO
+            : this.api.hap.Characteristic.TargetAirPurifierState.MANUAL;
+        const speed = this.homebridgeRotationSpeed(context);
+        // The mode switches are asked as well, because a move between two modes that are
+        // both manual and both without a wind control - `manual/high` to `bypass` - leaves
+        // the three purifier values identical and shows up only on the switches.
+        const modeSwitchMoved = this.modeSwitchServices(accessory).some((modeSwitch) =>
+            modeSwitch.getCharacteristic(this.api.hap.Characteristic.On).value
+                !== this.isModeSwitchOn(context, modeSwitch.subtype!));
+        if(service.getCharacteristic(this.api.hap.Characteristic.Active).value !== active
+            || service.getCharacteristic(this.api.hap.Characteristic.TargetAirPurifierState).value !== target
+            || service.getCharacteristic(this.api.hap.Characteristic.RotationSpeed).value !== speed
+            || modeSwitchMoved) {
+            this.log.debug("Vent :: %s :: publishing active=%s mode=%s speed=%s",
+                context.displayName, context.active ? "on" : "off", String(context.mode), String(speed));
+        }
         service.updateCharacteristic(this.api.hap.Characteristic.Active, context.active
             ? this.api.hap.Characteristic.Active.ACTIVE
             : this.api.hap.Characteristic.Active.INACTIVE);


### PR DESCRIPTION
## Summary

The Smart eLife accessories published their characteristics without saying anything, so a report that arrived and landed looked exactly like one that never arrived. Three of them — the outlet, the heater and the gas valve — had no log statement anywhere in the file, and the motion sensors were worse off still: they are single-shot events with no state left behind to inspect, so the log is the only thing that could ever answer for them. Nothing is misbehaving today; this is a wrap-up of the recent accessory work, putting each report on the record where it happens.

## Changes

- The vehicle, door, visitor camera and elevator arrival each write a debug line where the motion is published — one when it is reported, one when the hold expires. The configured hold duration is logged with the fire so a release that came too early is recognisable, and the duration expression is lifted into a local so the timer and the log cannot drift apart.
- The outlet, heater, gas valve and smart door lock log at the point of publication, gated on the value differing from what the characteristic already holds — the lightbulb's precedent. The device list is polled every thirty seconds, so an ungated line would bury the log it is meant to serve. The gates compare values in the form HAP stores them (a half-degree target rounds to the one-degree step), and they ask everything the reflection writes — all three of the air conditioner's services and the vent's mode switches — so a change that shows up on only one of them still speaks.
- The vent and the air conditioner log at the single point where device state reaches HomeKit. A gesture of ours already logs its own commands, which leaves a line here without one as the wallpad or the official app having moved the device.
- The indoor air quality sensor never publishes — its characteristics are read out of the context on GET — so its line records a polling cycle landing on the accessory, gated on the reading having moved.
- The visitor camera logs the snapshot swap, unconditionally: a visitor push is a one-shot event with no poll to repeat it, and until now only the failures to reach that point were on the record.
- No behavioural change. No characteristic write, command or timing is altered. Two small refactors serve the logging only: the reading object in the air quality poll, and a helper that asks whether what the heater is about to publish would land as a change.

## Testing

- `npm run build` for the type check.
- A local smoke harness drives the vehicle listener and the elevator arrival against stubbed clients, asserting that `MotionDetected` goes true and then false and that each transition is logged. A second harness drives the outlet, gas and heater listeners: a changed report logs exactly one line, three further polls of the same state log nothing, and no command leaves the accessory. All checks pass on this branch. Run against `main`, the characteristics still move while no line appears at all, which is the silence this closes.
- The vent, air conditioner, smart door lock, air quality and camera paths follow the same shape and pass the type check, but the harnesses do not exercise them.
- This branch was built and deployed to a Raspberry Pi running Homebridge 2.2.1 against a live Smart eLife household. Both bridges restarted cleanly with no warnings or errors, and the lines were observed on the device.
- Running it there is also what settled where the heater's gate belongs. A first build included the room's own temperature in it, and the line then came on every poll — six polls, six lines — because the sensor drifts a degree between readings with nobody touching anything. With that reading out of the gate and still printed on the line, the same household went ten polls without a word from the heater, and the outlet, gas valve, smart door lock, vent and air conditioner stayed silent too, none of them having changed. The air quality sensor speaks about once a minute, which is its readings genuinely moving.
- No motion event happened while it was running, so those four lines have been exercised by the harness and the type check but not yet seen in production.